### PR TITLE
Clean up some of the AI generated code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,9 +43,23 @@ else ()
     )
 endif ()
 
+if (BUILD_STATIC_LIBRARY AND BUILD_SHARED_LIBRARY)
+    message(
+        FATAL_ERROR
+        "It is not allowed to build both Shared and Static variant of the library simultaneously.
+Create separate build configurations if you need to build both variants of this library."
+    )
+endif()
+
 set(LIBLLKA_GLOBAL_DEFINITIONS -D_USE_MATH_DEFINES)
-set(LIBLLKA_BUILD_DEFINITIONS -DLLKA_DLL_BUILD)
 set(LIBLLKA_PLATFORM_DEFINITIONS "")
+
+if (BUILD_SHARED_LIBRARY)
+    set("LLKA_DLL_BUILD" "1")
+endif()
+if (BUILD_STATIC_LIBRARY)
+    set("LLKA_STATIC_BUILD" "1")
+endif()
 
 if (EMSCRIPTEN)
     set(BUILD_STATIC_LIBRARY ON)
@@ -299,7 +313,7 @@ if (EMSCRIPTEN)
             OUTPUT_NAME ${TARGET_OUTPUT_NAME}
             LINK_OPTIONS "--bind -fexceptions -sNO_DISABLE_EXCEPTION_CATCHING -sNODERAWFS=${EMX_EMCC_NODERAWFS} -sENVIRONMENT=${EMX_EMCC_ENV} -sWASM=${EMX_EMCC_WASM} -sALLOW_MEMORY_GROWTH -sMODULARIZE=${EMX_EMCC_MODULARIZE} -sEXPORT_ES6=${EMX_EMCC_ES6} ${EMX_OPTIFLAGS} ${EMX_OPTIFLAGS_LTO}"
     )
-    target_compile_definitions(libLLKA_STATIC PRIVATE ${LIBLLKA_GLOBAL_DEFINITIONS} ${LIBLLKA_BUILD_DEFINITIONS} ${LIBLLKA_PLATFORM_DEFINITIONS})
+    target_compile_definitions(libLLKA_STATIC PRIVATE ${LIBLLKA_GLOBAL_DEFINITIONS} ${LIBLLKA_PLATFORM_DEFINITIONS})
     target_link_libraries(libLLKA_STATIC ${LLKA_EXTRA_LINK_LIBS})
 
     set(LLKA_TARGETS ${LLKA_TARGETS} libLLKA_STATIC)
@@ -317,7 +331,7 @@ else ()
             PROPERTIES OUTPUT_NAME LLKA
             LINK_FLAGS ${DEFAULT_SYMVER_LINK}
         )
-        target_compile_definitions(libLLKA_STATIC PRIVATE ${LIBLLKA_GLOBAL_DEFINITIONS} ${LIBLLKA_BUILD_DEFINITIONS} ${LIBLLKA_PLATFORM_DEFINITIONS} -DLLKA_STATIC_BUILD)
+        target_compile_definitions(libLLKA_STATIC PRIVATE ${LIBLLKA_GLOBAL_DEFINITIONS} ${LIBLLKA_PLATFORM_DEFINITIONS})
         target_link_libraries(libLLKA_STATIC ${LLKA_EXTRA_LINK_LIBS})
 
         set(LLKA_TARGETS ${LLKA_TARGETS} libLLKA_STATIC)
@@ -332,7 +346,7 @@ else ()
                        OUTPUT_NAME LLKA
                        LINK_FLAGS ${DEFAULT_SYMVER_LINK}
         )
-        target_compile_definitions(libLLKA_SHARED PRIVATE ${LIBLLKA_GLOBAL_DEFINITIONS} ${LIBLLKA_BUILD_DEFINITIONS} ${LIBLLKA_PLATFORM_DEFINITIONS})
+        target_compile_definitions(libLLKA_SHARED PRIVATE ${LIBLLKA_GLOBAL_DEFINITIONS} ${LIBLLKA_PLATFORM_DEFINITIONS})
         target_link_libraries(libLLKA_SHARED ${LLKA_EXTRA_LINK_LIBS})
 
         set(LLKA_TARGETS ${LLKA_TARGETS} libLLKA_SHARED)

--- a/examples/classify_and_write_cif/CMakeLists.txt
+++ b/examples/classify_and_write_cif/CMakeLists.txt
@@ -1,9 +1,7 @@
 if (BUILD_STATIC_LIBRARY)
     set(LLKA_LIB_LINK libLLKA_STATIC)
-    set(LLKA_STATIC_DEFINE -DLLKA_STATIC_BUILD)
 else ()
     set(LLKA_LIB_LINK libLLKA_SHARED)
-    set(LLKA_STATIC_DEFINE "")
 endif ()
 
 # Simple NtC assignment example
@@ -12,7 +10,7 @@ add_executable(
     classify_and_write_cif.c
     dnatco_step_name.c
 )
-target_compile_definitions(classify_and_write_cif PRIVATE ${LIBLLKA_GLOBAL_DEFINITIONS} ${LIBLLKA_PLATFORM_DEFINITIONS} ${LLKA_STATIC_DEFINE})
+target_compile_definitions(classify_and_write_cif PRIVATE ${LIBLLKA_GLOBAL_DEFINITIONS} ${LIBLLKA_PLATFORM_DEFINITIONS})
 
 if (EMSCRIPTEN)
     set(MAYBE_EMX_LINK_FLAGS "-sALLOW_MEMORY_GROWTH -fexceptions")

--- a/examples/classify_and_write_cif/classify_and_write_cif.c
+++ b/examples/classify_and_write_cif/classify_and_write_cif.c
@@ -13,16 +13,12 @@
 
 ****************************************************************/
 
-#ifdef _WIN32
-#include <windows.h>
-#endif
-
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-#include <llka_module.h>
+#include <llka_platform_helpers.h>
 #include <llka_classification.h>
 #include <llka_minicif.h>
 #include <llka_nucleotide.h>
@@ -31,6 +27,7 @@
 
 /* We expect _USE_MATH_DEFINES to be defined */
 #include <math.h>
+
 
 #define CLUSTERS_FILE LLKA_PathLiteral("clusters.csv")
 #define CONFALS_FILE LLKA_PathLiteral("confals.csv")
@@ -58,58 +55,34 @@ LLKA_PathChar* create_full_path(const LLKA_PathChar *filename) {
     size_t subdir_length;
     size_t prefix_length;
 
-#ifdef LLKA_PLATFORM_WIN32
-    #define PATH_STRLEN wcslen
-    #define PATH_STRNCPY wcsncpy
-    #define PATH_SNPRINTF swprintf
-    #define PATH_FOPEN _wfopen
-    #define PATH_GETENV _wgetenv
-    #define PATH_TEXT(x) L##x
-#else
-    #define PATH_STRLEN strlen
-    #define PATH_STRNCPY strncpy
-    #define PATH_SNPRINTF snprintf
-    #define PATH_FOPEN fopen
-    #define PATH_GETENV getenv
-    #define PATH_TEXT(x) x
-#endif
-
     /* First, try the current working directory */
-    PATH_STRNCPY(full_path, filename, FULL_PATH_SIZE - 1);
-    full_path[FULL_PATH_SIZE - 1] = PATH_TEXT('\0'); /* Ensure null-termination */
+    LLKA_PHLP_STRNCPY(full_path, filename, FULL_PATH_SIZE - 1);
+    full_path[FULL_PATH_SIZE - 1] = LLKA_PathLiteral('\0'); /* Ensure null-termination */
 
-    test_file = PATH_FOPEN(full_path, PATH_TEXT("r"));
+    test_file = LLKA_PHLP_FOPEN(full_path, "r");
     if (test_file != NULL) {
         fclose(test_file);
         return full_path;
     }
 
     /* Second, try ${CCP4}/share/dnatco */
-    ccp4_path = PATH_GETENV(PATH_TEXT("CCP4"));
+    ccp4_path = LLKA_PHLP_GETENV("CCP4");
     if (ccp4_path != NULL) {
-        ccp4_length = PATH_STRLEN(ccp4_path);
-        filename_length = PATH_STRLEN(filename);
-        subdir = PATH_TEXT("/share/dnatco/");
-        subdir_length = PATH_STRLEN(subdir);
+        ccp4_length = LLKA_PHLP_STRLEN(ccp4_path);
+        filename_length = LLKA_PHLP_STRLEN(filename);
+        subdir = LLKA_PathLiteral("/share/dnatco/");
+        subdir_length = LLKA_PHLP_STRLEN(subdir);
 
         /* Check if the combined length exceeds the buffer size */
         if (ccp4_length + subdir_length + filename_length + 1 <= FULL_PATH_SIZE) {
             /* Check if the last character of the CCP4 path is a slash */
-            if (ccp4_path[ccp4_length - 1] != PATH_TEXT('/') && ccp4_path[ccp4_length - 1] != PATH_TEXT('\\')) {
-#ifdef LLKA_PLATFORM_WIN32
-                swprintf(full_path, FULL_PATH_SIZE, L"%s/share/dnatco/%s", ccp4_path, filename);
-#else
-                snprintf(full_path, FULL_PATH_SIZE, "%s/share/dnatco/%s", ccp4_path, filename);
-#endif
+            if (ccp4_path[ccp4_length - 1] != LLKA_PathLiteral('/') && ccp4_path[ccp4_length - 1] != LLKA_PathLiteral('\\')) {
+                LLKA_PHLP_SNPRINTF(full_path, FULL_PATH_SIZE, LLKA_PathLiteral("%s/share/dnatco/%s"), ccp4_path, filename);
             } else {
-#ifdef LLKA_PLATFORM_WIN32
-                swprintf(full_path, FULL_PATH_SIZE, L"%sshare/dnatco/%s", ccp4_path, filename);
-#else
-                snprintf(full_path, FULL_PATH_SIZE, "%sshare/dnatco/%s", ccp4_path, filename);
-#endif
+                LLKA_PHLP_SNPRINTF(full_path, FULL_PATH_SIZE, LLKA_PathLiteral("%s/share/dnatco/%s"), ccp4_path, filename);
             }
 
-            test_file = PATH_FOPEN(full_path, PATH_TEXT("r"));
+            test_file = LLKA_PHLP_FOPEN(full_path, "r");
             if (test_file != NULL) {
                 fclose(test_file);
                 return full_path;
@@ -118,11 +91,11 @@ LLKA_PathChar* create_full_path(const LLKA_PathChar *filename) {
     }
 
     /* Third, try DNATCO_ASSETS_PATH */
-    prefix_path = PATH_GETENV(PATH_TEXT("DNATCO_ASSETS_PATH"));
+    prefix_path = LLKA_PHLP_GETENV("DNATCO_ASSETS_PATH");
     if (prefix_path != NULL) {
         /* Calculate the length of the prefix path and filename */
-        prefix_length = PATH_STRLEN(prefix_path);
-        filename_length = PATH_STRLEN(filename);
+        prefix_length = LLKA_PHLP_STRLEN(prefix_path);
+        filename_length = LLKA_PHLP_STRLEN(filename);
 
         /* Check if the combined length exceeds the buffer size */
         if (prefix_length + filename_length + 2 > FULL_PATH_SIZE) {
@@ -131,21 +104,13 @@ LLKA_PathChar* create_full_path(const LLKA_PathChar *filename) {
         }
 
         /* Check if the last character of the prefix path is a slash */
-        if (prefix_path[prefix_length - 1] != PATH_TEXT('/') && prefix_path[prefix_length - 1] != PATH_TEXT('\\')) {
-#ifdef LLKA_PLATFORM_WIN32
-            swprintf(full_path, FULL_PATH_SIZE, L"%s/%s", prefix_path, filename);
-#else
-            snprintf(full_path, FULL_PATH_SIZE, "%s/%s", prefix_path, filename);
-#endif
+        if (prefix_path[prefix_length - 1] != LLKA_PathLiteral('/') && prefix_path[prefix_length - 1] != LLKA_PathLiteral('\\')) {
+            LLKA_PHLP_SNPRINTF(full_path, FULL_PATH_SIZE, LLKA_PathLiteral("%s/%s"), prefix_path, filename);
         } else {
-#ifdef LLKA_PLATFORM_WIN32
-            swprintf(full_path, FULL_PATH_SIZE, L"%s%s", prefix_path, filename);
-#else
-            snprintf(full_path, FULL_PATH_SIZE, "%s%s", prefix_path, filename);
-#endif
+            LLKA_PHLP_SNPRINTF(full_path, FULL_PATH_SIZE, LLKA_PathLiteral("%s/%s"), prefix_path, filename);
         }
 
-        test_file = PATH_FOPEN(full_path, PATH_TEXT("r"));
+        test_file = LLKA_PHLP_FOPEN(full_path, "r");
         if (test_file != NULL) {
             fclose(test_file);
             return full_path;
@@ -153,15 +118,9 @@ LLKA_PathChar* create_full_path(const LLKA_PathChar *filename) {
     }
 
     /* If file not found in any location, return the cwd path (will fail later with appropriate error) */
-    PATH_STRNCPY(full_path, filename, FULL_PATH_SIZE - 1);
-    full_path[FULL_PATH_SIZE - 1] = PATH_TEXT('\0');
+    LLKA_PHLP_STRNCPY(full_path, filename, FULL_PATH_SIZE - 1);
+    full_path[FULL_PATH_SIZE - 1] = LLKA_PathLiteral('\0');
 
-#undef PATH_STRLEN
-#undef PATH_STRNCPY
-#undef PATH_SNPRINTF
-#undef PATH_FOPEN
-#undef PATH_GETENV
-#undef PATH_TEXT
     return full_path;
 }
 
@@ -1067,11 +1026,7 @@ int main(int argc, char *argv[])
 
     /* Read structure from Cif and assign NtCs */
 
-#ifdef LLKA_PLATFORM_WIN32
-    if (argc > 1 && wcscmp(argv[1], L"--version") == 0) {
-#else
-    if (argc > 1 && strcmp(argv[1], "--version") == 0) {
-#endif
+    if (argc > 1 && LLKA_PHLP_STRCMP(argv[1], LLKA_PathLiteral("--version")) == 0) {
         printf("classify_and_write_cif version 0.0.2\n");
         printf("DNATCO v5.0, NtC v" LLKA_INTERNAL_NTC_VERSION ", CANA v" LLKA_INTERNAL_CANA_VERSION "\n");
         return 0;

--- a/examples/gui_assigner/CMakeLists.txt
+++ b/examples/gui_assigner/CMakeLists.txt
@@ -1,9 +1,7 @@
 if (BUILD_STATIC_LIBRARY)
     set(LLKA_LIB_LINK libLLKA_STATIC)
-    set(LLKA_STATIC_DEFINE -DLLKA_STATIC_BUILD)
 else ()
     set(LLKA_LIB_LINK libLLKA_SHARED)
-    set(LLKA_STATIC_DEFINE "")
 endif ()
 
 find_package(Qt6 COMPONENTS Core Gui Widgets)
@@ -29,7 +27,7 @@ if (WIN32)
 else ()
     add_executable(gui_assigner ${gui_assigner_SRCS})
 endif ()
-target_compile_definitions(gui_assigner PRIVATE ${LIBLLKA_GLOBAL_DEFINITIONS} ${LIBLLKA_PLATFORM_DEFINITIONS} ${LLKA_STATIC_DEFINE})
+target_compile_definitions(gui_assigner PRIVATE ${LIBLLKA_GLOBAL_DEFINITIONS} ${LIBLLKA_PLATFORM_DEFINITIONS})
 target_link_libraries(
     gui_assigner
     PRIVATE ${LLKA_LIB_LINK}

--- a/examples/mirror_cif/CMakeLists.txt
+++ b/examples/mirror_cif/CMakeLists.txt
@@ -1,9 +1,7 @@
 if (BUILD_STATIC_LIBRARY)
     set(LLKA_LIB_LINK libLLKA_STATIC)
-    set(LLKA_STATIC_DEFINE -DLLKA_STATIC_BUILD)
 else ()
     set(LLKA_LIB_LINK libLLKA_SHARED)
-    set(LLKA_STATIC_DEFINE "")
 endif ()
 
 # Simple NtC assignment example
@@ -16,7 +14,7 @@ set_target_properties(
     PROPERTIES
         LANGUAGE C
 )
-target_compile_definitions(mirror_cif PRIVATE ${LIBLLKA_GLOBAL_DEFINITIONS} ${LIBLLKA_PLATFORM_DEFINITIONS} ${LLKA_STATIC_DEFINE})
+target_compile_definitions(mirror_cif PRIVATE ${LIBLLKA_GLOBAL_DEFINITIONS} ${LIBLLKA_PLATFORM_DEFINITIONS})
 
 if (EMSCRIPTEN)
     set(MAYBE_EMX_LINK_FLAGS "-sALLOW_MEMORY_GROWTH -fexceptions")

--- a/examples/mirror_cif/mirror_cif.c
+++ b/examples/mirror_cif/mirror_cif.c
@@ -50,7 +50,11 @@ void mirror(const LLKA_CifData *data)
     }
 }
 
-int main(int argc, char *argv[])
+#ifdef LLKA_PLATFORM_WIN32
+int wmain(int argc, wchar_t* argv[])
+#else
+int main(int argc, char* argv[])
+#endif /* LLKA_PLATFORM_ */
 {
     LLKA_CifData *data;
     LLKA_RetCode tRet;

--- a/examples/similarity_connectivity/CMakeLists.txt
+++ b/examples/similarity_connectivity/CMakeLists.txt
@@ -1,9 +1,7 @@
 if (BUILD_STATIC_LIBRARY)
     set(LLKA_LIB_LINK libLLKA_STATIC)
-    set(LLKA_STATIC_DEFINE -DLLKA_STATIC_BUILD)
 else ()
     set(LLKA_LIB_LINK libLLKA_SHARED)
-    set(LLKA_STATIC_DEFINE "")
 endif ()
 
 # Simple NtC assignment example
@@ -11,7 +9,7 @@ add_executable(
     similarity_connectivity
     similarity_connectivity.cpp
 )
-target_compile_definitions(similarity_connectivity PRIVATE ${LIBLLKA_GLOBAL_DEFINITIONS} ${LIBLLKA_PLATFORM_DEFINITIONS} ${LLKA_STATIC_DEFINE})
+target_compile_definitions(similarity_connectivity PRIVATE ${LIBLLKA_GLOBAL_DEFINITIONS} ${LIBLLKA_PLATFORM_DEFINITIONS})
 
 if (EMSCRIPTEN)
     set(MAYBE_EMX_LINK_FLAGS "-sALLOW_MEMORY_GROWTH -fexceptions")

--- a/examples/similarity_connectivity/similarity_connectivity.cpp
+++ b/examples/similarity_connectivity/similarity_connectivity.cpp
@@ -13,7 +13,7 @@
 #include <string.h>
 #include <assert.h>
 
-#include <llka_module.h>
+#include <llka_platform_helpers.h>
 
 #include <json.hpp>
 #include <CLI11.hpp>
@@ -90,63 +90,47 @@ typedef struct LLKA_AnalyzedSteps{
     size_t nSteps;
 } LLKA_AnalyzedSteps;
 
-LLKA_PathChar* create_full_path(const LLKA_PathChar *filename) {
+LLKA_PathChar* create_full_path(const LLKA_PathChar* filename) {
     /* Allocate memory for the full path */
     static LLKA_PathChar full_path[FULL_PATH_SIZE];
-    FILE *test_file;
-
-#ifdef LLKA_PLATFORM_WIN32
-    #define PATH_STRLEN wcslen
-    #define PATH_STRNCPY wcsncpy
-    #define PATH_SNPRINTF swprintf
-    #define PATH_FOPEN _wfopen
-    #define PATH_GETENV _wgetenv
-    #define PATH_TEXT(x) L##x
-#else
-    #define PATH_STRLEN strlen
-    #define PATH_STRNCPY strncpy
-    #define PATH_SNPRINTF snprintf
-    #define PATH_FOPEN fopen
-    #define PATH_GETENV getenv
-    #define PATH_TEXT(x) x
-#endif
+    FILE* test_file;
+    const LLKA_PathChar* ccp4_path;
+    const LLKA_PathChar* prefix_path;
+    size_t ccp4_length;
+    size_t filename_length;
+    const LLKA_PathChar* subdir;
+    size_t subdir_length;
+    size_t prefix_length;
 
     /* First, try the current working directory */
-    PATH_STRNCPY(full_path, filename, FULL_PATH_SIZE - 1);
-    full_path[FULL_PATH_SIZE - 1] = PATH_TEXT('\0'); /* Ensure null-termination */
+    LLKA_PHLP_STRNCPY(full_path, filename, FULL_PATH_SIZE - 1);
+    full_path[FULL_PATH_SIZE - 1] = LLKA_PathLiteral('\0'); /* Ensure null-termination */
 
-    test_file = PATH_FOPEN(full_path, PATH_TEXT("r"));
+    test_file = LLKA_PHLP_FOPEN(full_path, "r");
     if (test_file != NULL) {
         fclose(test_file);
         return full_path;
     }
 
     /* Second, try ${CCP4}/share/dnatco */
-    const LLKA_PathChar *ccp4_path = PATH_GETENV(PATH_TEXT("CCP4"));
+    ccp4_path = LLKA_PHLP_GETENV("CCP4");
     if (ccp4_path != NULL) {
-        size_t ccp4_length = PATH_STRLEN(ccp4_path);
-        size_t filename_length = PATH_STRLEN(filename);
-        const LLKA_PathChar *subdir = PATH_TEXT("/share/dnatco/");
-        size_t subdir_length = PATH_STRLEN(subdir);
+        ccp4_length = LLKA_PHLP_STRLEN(ccp4_path);
+        filename_length = LLKA_PHLP_STRLEN(filename);
+        subdir = LLKA_PathLiteral("/share/dnatco/");
+        subdir_length = LLKA_PHLP_STRLEN(subdir);
 
         /* Check if the combined length exceeds the buffer size */
         if (ccp4_length + subdir_length + filename_length + 1 <= FULL_PATH_SIZE) {
             /* Check if the last character of the CCP4 path is a slash */
-            if (ccp4_path[ccp4_length - 1] != PATH_TEXT('/') && ccp4_path[ccp4_length - 1] != PATH_TEXT('\\')) {
-#ifdef LLKA_PLATFORM_WIN32
-                swprintf(full_path, FULL_PATH_SIZE, L"%s/share/dnatco/%s", ccp4_path, filename);
-#else
-                snprintf(full_path, FULL_PATH_SIZE, "%s/share/dnatco/%s", ccp4_path, filename);
-#endif
-            } else {
-#ifdef LLKA_PLATFORM_WIN32
-                swprintf(full_path, FULL_PATH_SIZE, L"%sshare/dnatco/%s", ccp4_path, filename);
-#else
-                snprintf(full_path, FULL_PATH_SIZE, "%sshare/dnatco/%s", ccp4_path, filename);
-#endif
+            if (ccp4_path[ccp4_length - 1] != LLKA_PathLiteral('/') && ccp4_path[ccp4_length - 1] != LLKA_PathLiteral('\\')) {
+                LLKA_PHLP_SNPRINTF(full_path, FULL_PATH_SIZE, LLKA_PathLiteral("%s/share/dnatco/%s"), ccp4_path, filename);
+            }
+            else {
+                LLKA_PHLP_SNPRINTF(full_path, FULL_PATH_SIZE, LLKA_PathLiteral("%s/share/dnatco/%s"), ccp4_path, filename);
             }
 
-            test_file = PATH_FOPEN(full_path, PATH_TEXT("r"));
+            test_file = LLKA_PHLP_FOPEN(full_path, "r");
             if (test_file != NULL) {
                 fclose(test_file);
                 return full_path;
@@ -155,11 +139,11 @@ LLKA_PathChar* create_full_path(const LLKA_PathChar *filename) {
     }
 
     /* Third, try DNATCO_ASSETS_PATH */
-    const LLKA_PathChar *prefix_path = PATH_GETENV(PATH_TEXT("DNATCO_ASSETS_PATH"));
+    prefix_path = LLKA_PHLP_GETENV("DNATCO_ASSETS_PATH");
     if (prefix_path != NULL) {
         /* Calculate the length of the prefix path and filename */
-        size_t prefix_length = PATH_STRLEN(prefix_path);
-        size_t filename_length = PATH_STRLEN(filename);
+        prefix_length = LLKA_PHLP_STRLEN(prefix_path);
+        filename_length = LLKA_PHLP_STRLEN(filename);
 
         /* Check if the combined length exceeds the buffer size */
         if (prefix_length + filename_length + 2 > FULL_PATH_SIZE) {
@@ -168,21 +152,14 @@ LLKA_PathChar* create_full_path(const LLKA_PathChar *filename) {
         }
 
         /* Check if the last character of the prefix path is a slash */
-        if (prefix_path[prefix_length - 1] != PATH_TEXT('/') && prefix_path[prefix_length - 1] != PATH_TEXT('\\')) {
-#ifdef LLKA_PLATFORM_WIN32
-            swprintf(full_path, FULL_PATH_SIZE, L"%s/%s", prefix_path, filename);
-#else
-            snprintf(full_path, FULL_PATH_SIZE, "%s/%s", prefix_path, filename);
-#endif
-        } else {
-#ifdef LLKA_PLATFORM_WIN32
-            swprintf(full_path, FULL_PATH_SIZE, L"%s%s", prefix_path, filename);
-#else
-            snprintf(full_path, FULL_PATH_SIZE, "%s%s", prefix_path, filename);
-#endif
+        if (prefix_path[prefix_length - 1] != LLKA_PathLiteral('/') && prefix_path[prefix_length - 1] != LLKA_PathLiteral('\\')) {
+            LLKA_PHLP_SNPRINTF(full_path, FULL_PATH_SIZE, LLKA_PathLiteral("%s/%s"), prefix_path, filename);
+        }
+        else {
+            LLKA_PHLP_SNPRINTF(full_path, FULL_PATH_SIZE, LLKA_PathLiteral("%s/%s"), prefix_path, filename);
         }
 
-        test_file = PATH_FOPEN(full_path, PATH_TEXT("r"));
+        test_file = LLKA_PHLP_FOPEN(full_path, "r");
         if (test_file != NULL) {
             fclose(test_file);
             return full_path;
@@ -190,16 +167,10 @@ LLKA_PathChar* create_full_path(const LLKA_PathChar *filename) {
     }
 
     /* If file not found in any location, return the cwd path (will fail later with appropriate error) */
-    PATH_STRNCPY(full_path, filename, FULL_PATH_SIZE - 1);
-    full_path[FULL_PATH_SIZE - 1] = PATH_TEXT('\0');
-    return full_path;
+    LLKA_PHLP_STRNCPY(full_path, filename, FULL_PATH_SIZE - 1);
+    full_path[FULL_PATH_SIZE - 1] = LLKA_PathLiteral('\0');
 
-#undef PATH_STRLEN
-#undef PATH_STRNCPY
-#undef PATH_SNPRINTF
-#undef PATH_FOPEN
-#undef PATH_GETENV
-#undef PATH_TEXT
+    return full_path;
 }
 
 /* DNATCO step name functions signatures */

--- a/examples/similarity_connectivity/similarity_connectivity.cpp
+++ b/examples/similarity_connectivity/similarity_connectivity.cpp
@@ -224,6 +224,31 @@ void stepAltIds(const LLKA_Structure *stru, char *altIdFirst, char *altIdSecond)
     }
 }
 
+#ifdef LLKA_PLATFORM_WIN32
+
+std::wstring inputToFilePath(const std::string &filePathIn)
+{
+    auto wlen = MultiByteToWideChar(CP_UTF8, 0, filePathIn.c_str(), -1, nullptr, 0);
+    if (wlen == 0) {
+        fprintf(stderr, "Cannot process input path to mmcif file, error %d", GetLastError());
+        abort();
+    }
+
+    std::vector<wchar_t> buf(wlen, '\0');
+    MultiByteToWideChar(CP_UTF8, 0, filePathIn.c_str(), -1, buf.data(), wlen);
+
+    return std::wstring(buf.data());
+}
+
+#else
+
+std::string inputToFilePath(std::string filePathIn)
+{
+    return filePathIn;
+}
+
+#endif // LLKA_PLATFORM_
+
 char * deriveDNATCOStepName(const char *entryId, int hasMultipleModels, const LLKA_Structure *step)
 {
     char altIdFirst, altIdSecond;
@@ -1830,19 +1855,15 @@ int main(int argc, char *argv[])
     }
 
     // Read structure from Cif File
-#ifdef LLKA_PLATFORM_WIN32
-    // Convert UTF-8 string to wide string on Windows
-    int wlen = MultiByteToWideChar(CP_UTF8, 0, filename.c_str(), -1, NULL, 0);
-    wchar_t *wfilename = new wchar_t[wlen];
-    MultiByteToWideChar(CP_UTF8, 0, filename.c_str(), -1, wfilename, wlen);
-    bool cifResult = makeStructureFromCif(wfilename, &importedStru);
-    delete[] wfilename;
-    if (!cifResult)
+    if(filename.size() == 0){
+        fprintf(stderr, "mmcif file path cannot be empty");
+        exit(1);
+    }
+
+    auto filepathInternal = inputToFilePath(filename);
+    if (!makeStructureFromCif(filepathInternal.c_str(), &importedStru))
         return EXIT_FAILURE;
-#else
-    if (!makeStructureFromCif(filename.c_str(), &importedStru))
-        return EXIT_FAILURE;
-#endif
+
 
     tRet = LLKA_splitStructureToDinucleotideSteps(&importedStru.structure, &steps);
     if (tRet != LLKA_OK) {

--- a/examples/simple_NtC_assignment/CMakeLists.txt
+++ b/examples/simple_NtC_assignment/CMakeLists.txt
@@ -1,9 +1,7 @@
 if (BUILD_STATIC_LIBRARY)
     set(LLKA_LIB_LINK libLLKA_STATIC)
-    set(LLKA_STATIC_DEFINE -DLLKA_STATIC_BUILD)
 else ()
     set(LLKA_LIB_LINK libLLKA_SHARED)
-    set(LLKA_STATIC_DEFINE "")
 endif ()
 
 # Simple NtC assignment example
@@ -17,7 +15,7 @@ set_target_properties(
     PROPERTIES
         LANGUAGE C
 )
-target_compile_definitions(simple_NtC_assignment PRIVATE ${LIBLLKA_GLOBAL_DEFINITIONS} ${LIBLLKA_PLATFORM_DEFINITIONS} ${LLKA_STATIC_DEFINE})
+target_compile_definitions(simple_NtC_assignment PRIVATE ${LIBLLKA_GLOBAL_DEFINITIONS} ${LIBLLKA_PLATFORM_DEFINITIONS})
 target_link_libraries(simple_NtC_assignment ${LLKA_LIB_LINK})
 
 if (EMSCRIPTEN)

--- a/include/llka_config.h.in
+++ b/include/llka_config.h.in
@@ -5,4 +5,7 @@
 #cmakedefine LLKA_PLATFORM_UNIX
 #cmakedefine LLKA_PLATFORM_EMSCRIPTEN
 
+#cmakedefine LLKA_STATIC_BUILD
+#cmakedefine LLKA_DLL_BUILD
+
 #endif /* _LLKA_CONFIG_H */

--- a/include/llka_module.h
+++ b/include/llka_module.h
@@ -235,7 +235,9 @@
 #ifdef LLKA_HAVE_SAD_LADY_COMPILER
     #define LLKA_SAD_CONSTEXPR_FUNC
     #define LLKA_SAD_CONSTEXPR_VAR const
+    #define LLKA_SAD_CONSTINIT const
 #else
     #define LLKA_SAD_CONSTEXPR_FUNC constexpr
     #define LLKA_SAD_CONSTEXPR_VAR constexpr
+    #define LLKA_SAD_CONSTINIT constinit
 #endif /* LLKA_HAVE_SAD_LADY_COMPILER */

--- a/include/llka_platform_helpers.h
+++ b/include/llka_platform_helpers.h
@@ -1,0 +1,26 @@
+/* vim: set sw=4 ts=4 sts=4 expandtab : */
+
+#ifndef _LLKA_PLATFORM_HELPERS_H
+#define _LLKA_PLATFORM_HELPERS_H
+
+#include <llka_module.h>
+
+#ifdef LLKA_PLATFORM_WIN32
+    #include <windows.h>
+
+    #define LLKA_PHLP_STRCMP wcscmp
+    #define LLKA_PHLP_STRLEN wcslen
+    #define LLKA_PHLP_STRNCPY wcsncpy
+    #define LLKA_PHLP_FOPEN(path, mode) _wfopen(path, L##mode)
+    #define LLKA_PHLP_GETENV(variable_name) _wgetenv(L##variable_name)
+    #define LLKA_PHLP_SNPRINTF swprintf
+#else
+    #define LLKA_PHLP_STRCMP strcmp
+    #define LLKA_PHLP_STRLEN strlen
+    #define LLKA_PHLP_STRNCPY strncpy
+    #define LLKA_PHLP_FOPEN fopen
+    #define LLKA_PHLP_GETENV getenv
+    #define LLKA_PHLP_SNPRINTF snprintf
+#endif
+
+#endif /* _LLKA_PLATFORM_HELPERS_H */

--- a/src/classification.cpp
+++ b/src/classification.cpp
@@ -61,19 +61,19 @@ namespace LLKAInternal {
 inline constinit double MINIMUM_ALLOWED_DELTA = D2R(55.0);
 inline constinit double MAXIMUM_ALLOWED_DELTA = D2R(185.0);
 
-inline constinit std::array<double LLKA_StepMetrics::*, 9> ALL_TORSIONS_STEP_METRIC_CLSPTRS{
+inline LLKA_SAD_CONSTINIT std::array<double LLKA_StepMetrics::*, 9> ALL_TORSIONS_STEP_METRIC_CLSPTRS{
     &LLKA_StepMetrics::delta_1, &LLKA_StepMetrics::epsilon_1, &LLKA_StepMetrics::zeta_1, &LLKA_StepMetrics::alpha_2, &LLKA_StepMetrics::beta_2,
     &LLKA_StepMetrics::gamma_2, &LLKA_StepMetrics::delta_2, &LLKA_StepMetrics::chi_1, &LLKA_StepMetrics::chi_2
 };
-inline constinit std::array<LLKA_ClassificationMetric LLKA_ClassificationCluster::*, 9> ALL_TORSIONS_CLASSIFICATION_METRIC_CLSPTRS{
+inline LLKA_SAD_CONSTINIT std::array<LLKA_ClassificationMetric LLKA_ClassificationCluster::*, 9> ALL_TORSIONS_CLASSIFICATION_METRIC_CLSPTRS{
     &LLKA_ClassificationCluster::delta_1, &LLKA_ClassificationCluster::epsilon_1, &LLKA_ClassificationCluster::zeta_1, &LLKA_ClassificationCluster::alpha_2, &LLKA_ClassificationCluster::beta_2,
     &LLKA_ClassificationCluster::gamma_2, &LLKA_ClassificationCluster::delta_2, &LLKA_ClassificationCluster::chi_1, &LLKA_ClassificationCluster::chi_2
 };
-inline constinit std::array<double LLKA_Confal::*, 9> ALL_TORSIONS_CONFAL_CLSPTRS{
+inline LLKA_SAD_CONSTINIT std::array<double LLKA_Confal::*, 9> ALL_TORSIONS_CONFAL_CLSPTRS{
     &LLKA_Confal::delta_1, &LLKA_Confal::epsilon_1, &LLKA_Confal::zeta_1, &LLKA_Confal::alpha_2, &LLKA_Confal::beta_2,
     &LLKA_Confal::gamma_2, &LLKA_Confal::delta_2, &LLKA_Confal::chi_1, &LLKA_Confal::chi_2
 };
-inline constinit std::array<double LLKA_ConfalScore::*, 9> ALL_TORSIONS_CONFAL_SCORE_CLSPTRS{
+inline LLKA_SAD_CONSTINIT std::array<double LLKA_ConfalScore::*, 9> ALL_TORSIONS_CONFAL_SCORE_CLSPTRS{
     &LLKA_ConfalScore::delta_1, &LLKA_ConfalScore::epsilon_1, &LLKA_ConfalScore::zeta_1, &LLKA_ConfalScore::alpha_2, &LLKA_ConfalScore::beta_2,
     &LLKA_ConfalScore::gamma_2, &LLKA_ConfalScore::delta_2, &LLKA_ConfalScore::chi_1, &LLKA_ConfalScore::chi_2
 };
@@ -81,22 +81,22 @@ static_assert(ALL_TORSIONS_STEP_METRIC_CLSPTRS.size() == ALL_TORSIONS_CLASSIFICA
 static_assert(ALL_TORSIONS_STEP_METRIC_CLSPTRS.size() == ALL_TORSIONS_CONFAL_CLSPTRS.size());
 static_assert(ALL_TORSIONS_STEP_METRIC_CLSPTRS.size() == ALL_TORSIONS_CONFAL_SCORE_CLSPTRS.size());
 
-inline constinit std::array<double LLKA_StepMetrics::*, 10> TORSION_STEP_METRIC_CLSPTRS{
+inline LLKA_SAD_CONSTINIT std::array<double LLKA_StepMetrics::*, 10> TORSION_STEP_METRIC_CLSPTRS{
     &LLKA_StepMetrics::delta_1, &LLKA_StepMetrics::epsilon_1, &LLKA_StepMetrics::zeta_1, &LLKA_StepMetrics::alpha_2, &LLKA_StepMetrics::beta_2,
     &LLKA_StepMetrics::gamma_2, &LLKA_StepMetrics::delta_2, &LLKA_StepMetrics::chi_1, &LLKA_StepMetrics::chi_2,
     &LLKA_StepMetrics::mu
 };
-inline constinit std::array<LLKA_ClassificationMetric LLKA_ClassificationCluster::*, 10> TORSION_CLASSIFICATION_METRIC_CLSPTRS{
+inline LLKA_SAD_CONSTINIT std::array<LLKA_ClassificationMetric LLKA_ClassificationCluster::*, 10> TORSION_CLASSIFICATION_METRIC_CLSPTRS{
     &LLKA_ClassificationCluster::delta_1, &LLKA_ClassificationCluster::epsilon_1, &LLKA_ClassificationCluster::zeta_1, &LLKA_ClassificationCluster::alpha_2, &LLKA_ClassificationCluster::beta_2,
     &LLKA_ClassificationCluster::gamma_2, &LLKA_ClassificationCluster::delta_2, &LLKA_ClassificationCluster::chi_1, &LLKA_ClassificationCluster::chi_2,
     &LLKA_ClassificationCluster::mu
 };
 static_assert(TORSION_STEP_METRIC_CLSPTRS.size() == TORSION_CLASSIFICATION_METRIC_CLSPTRS.size());
 
-inline constinit std::array<LLKA_ClassificationMetric LLKA_NuAnglesMetrics::*, 5> NU_ANGLES_METRICS_CLSPTRS{
+inline LLKA_SAD_CONSTINIT std::array<LLKA_ClassificationMetric LLKA_NuAnglesMetrics::*, 5> NU_ANGLES_METRICS_CLSPTRS{
     &LLKA_NuAnglesMetrics::nu_0, &LLKA_NuAnglesMetrics::nu_1, &LLKA_NuAnglesMetrics::nu_2, &LLKA_NuAnglesMetrics::nu_3, &LLKA_NuAnglesMetrics::nu_4
 };
-inline constinit std::array<double LLKA_NuAngles::*, 5> NU_ANGLES_CLSPTRS{
+inline LLKA_SAD_CONSTINIT std::array<double LLKA_NuAngles::*, 5> NU_ANGLES_CLSPTRS{
     &LLKA_NuAngles::nu_0, &LLKA_NuAngles::nu_1, &LLKA_NuAngles::nu_2, &LLKA_NuAngles::nu_3, &LLKA_NuAngles::nu_4
 };
 static_assert(NU_ANGLES_METRICS_CLSPTRS.size() == NU_ANGLES_CLSPTRS.size());

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,9 +1,7 @@
 if (BUILD_STATIC_LIBRARY)
     set(LLKA_LIB_LINK libLLKA_STATIC)
-    set(LLKA_STATIC_DEFINE -DLLKA_STATIC_BUILD)
 else ()
     set(LLKA_LIB_LINK libLLKA_SHARED)
-    set(LLKA_STATIC_DEFINE "")
 endif ()
 
 set(CPP_EXTRA_LINK "")
@@ -12,63 +10,63 @@ if (EMSCRIPTEN)
 endif ()
 
 add_executable(test_basics test_basics.cpp effedup.cpp)
-target_compile_definitions(test_basics PRIVATE ${LIBLLKA_GLOBAL_DEFINITIONS} ${LIBLLKA_PLATFORM_DEFINITIONS} ${LLKA_STATIC_DEFINE})
+target_compile_definitions(test_basics PRIVATE ${LIBLLKA_GLOBAL_DEFINITIONS} ${LIBLLKA_PLATFORM_DEFINITIONS})
 target_link_libraries(test_basics ${LLKA_LIB_LINK})
 add_test(NAME Basics COMMAND test_basics)
 
 add_executable(test_structure_manipulation test_structure_manipulation.cpp effedup.cpp)
-target_compile_definitions(test_structure_manipulation PRIVATE ${LIBLLKA_GLOBAL_DEFINITIONS} ${LIBLLKA_PLATFORM_DEFINITIONS} ${LLKA_STATIC_DEFINE})
+target_compile_definitions(test_structure_manipulation PRIVATE ${LIBLLKA_GLOBAL_DEFINITIONS} ${LIBLLKA_PLATFORM_DEFINITIONS})
 target_link_libraries(test_structure_manipulation ${LLKA_LIB_LINK})
 add_test(NAME StructureManipulation COMMAND test_structure_manipulation)
 
 add_executable(test_structure_splitting test_structure_splitting.cpp effedup.cpp)
-target_compile_definitions(test_structure_splitting PRIVATE ${LIBLLKA_GLOBAL_DEFINITIONS} ${LIBLLKA_PLATFORM_DEFINITIONS} ${LLKA_STATIC_DEFINE})
+target_compile_definitions(test_structure_splitting PRIVATE ${LIBLLKA_GLOBAL_DEFINITIONS} ${LIBLLKA_PLATFORM_DEFINITIONS})
 target_link_libraries(test_structure_splitting PRIVATE ${LLKA_LIB_LINK})
 add_test(NAME StructureSplitting COMMAND test_structure_splitting)
 
 add_executable(test_segmentation test_segmentation.cpp effedup.cpp)
-target_compile_definitions(test_segmentation PRIVATE ${LIBLLKA_GLOBAL_DEFINITIONS} ${LIBLLKA_PLATFORM_DEFINITIONS} ${LLKA_STATIC_DEFINE})
+target_compile_definitions(test_segmentation PRIVATE ${LIBLLKA_GLOBAL_DEFINITIONS} ${LIBLLKA_PLATFORM_DEFINITIONS})
 target_link_libraries(test_segmentation PRIVATE ${LLKA_LIB_LINK})
 add_test(NAME Segmentation COMMAND test_segmentation)
 
 add_executable(test_extract_backbone test_extract_backbone.cpp effedup.cpp)
-target_compile_definitions(test_extract_backbone PRIVATE ${LIBLLKA_GLOBAL_DEFINITIONS} ${LIBLLKA_PLATFORM_DEFINITIONS} ${LLKA_STATIC_DEFINE})
+target_compile_definitions(test_extract_backbone PRIVATE ${LIBLLKA_GLOBAL_DEFINITIONS} ${LIBLLKA_PLATFORM_DEFINITIONS})
 target_link_libraries(test_extract_backbone ${LLKA_LIB_LINK})
 add_test(NAME ExtractBackbone COMMAND test_extract_backbone)
 
 add_executable(test_nucleotide test_nucleotide.cpp effedup.cpp)
-target_compile_definitions(test_nucleotide PRIVATE ${LIBLLKA_GLOBAL_DEFINITIONS} ${LIBLLKA_PLATFORM_DEFINITIONS} ${LLKA_STATIC_DEFINE})
+target_compile_definitions(test_nucleotide PRIVATE ${LIBLLKA_GLOBAL_DEFINITIONS} ${LIBLLKA_PLATFORM_DEFINITIONS})
 target_link_libraries(test_nucleotide ${LLKA_LIB_LINK})
 add_test(NAME Nucleotide COMMAND test_nucleotide)
 
 add_executable(test_ntc test_ntc.cpp effedup.cpp)
-target_compile_definitions(test_ntc PRIVATE ${LIBLLKA_GLOBAL_DEFINITIONS} ${LIBLLKA_PLATFORM_DEFINITIONS} ${LLKA_STATIC_DEFINE})
+target_compile_definitions(test_ntc PRIVATE ${LIBLLKA_GLOBAL_DEFINITIONS} ${LIBLLKA_PLATFORM_DEFINITIONS})
 target_link_libraries(test_ntc ${LLKA_LIB_LINK})
 add_test(NAME NtC COMMAND test_ntc)
 
 add_executable(test_superposition test_superposition.cpp effedup.cpp)
-target_compile_definitions(test_superposition PRIVATE ${LIBLLKA_GLOBAL_DEFINITIONS} ${LIBLLKA_PLATFORM_DEFINITIONS} ${LLKA_STATIC_DEFINE})
+target_compile_definitions(test_superposition PRIVATE ${LIBLLKA_GLOBAL_DEFINITIONS} ${LIBLLKA_PLATFORM_DEFINITIONS})
 target_link_libraries(test_superposition ${LLKA_LIB_LINK})
 add_test(NAME Superposition COMMAND test_superposition)
 
 add_executable(test_connectivity test_connectivity.cpp effedup.cpp)
-target_compile_definitions(test_connectivity PRIVATE ${LIBLLKA_GLOBAL_DEFINITIONS} ${LIBLLKA_PLATFORM_DEFINITIONS} ${LLKA_STATIC_DEFINE})
+target_compile_definitions(test_connectivity PRIVATE ${LIBLLKA_GLOBAL_DEFINITIONS} ${LIBLLKA_PLATFORM_DEFINITIONS})
 target_link_libraries(test_connectivity ${LLKA_LIB_LINK})
 add_test(NAME Connectivity COMMAND test_connectivity)
 
 add_executable(test_similarity test_similarity.cpp effedup.cpp)
-target_compile_definitions(test_similarity PRIVATE ${LIBLLKA_GLOBAL_DEFINITIONS} ${LIBLLKA_PLATFORM_DEFINITIONS} ${LLKA_STATIC_DEFINE})
+target_compile_definitions(test_similarity PRIVATE ${LIBLLKA_GLOBAL_DEFINITIONS} ${LIBLLKA_PLATFORM_DEFINITIONS})
 target_link_libraries(test_similarity ${LLKA_LIB_LINK})
 add_test(NAME Similarity COMMAND test_similarity)
 
 add_executable(test_measurements test_measurements.cpp effedup.cpp)
-target_compile_definitions(test_measurements PRIVATE ${LIBLLKA_GLOBAL_DEFINITIONS} ${LIBLLKA_PLATFORM_DEFINITIONS} ${LLKA_STATIC_DEFINE})
+target_compile_definitions(test_measurements PRIVATE ${LIBLLKA_GLOBAL_DEFINITIONS} ${LIBLLKA_PLATFORM_DEFINITIONS})
 target_link_libraries(test_measurements ${LLKA_LIB_LINK})
 add_test(NAME Measurements COMMAND test_measurements)
 
 if ((NOT EMSCRIPTEN) OR (EMX_JS_BUILD_MODE STREQUAL "Node") OR (EMX_JS_BUILD_MODE STREQUAL "Node_SIMD"))
     add_executable(test_classification test_classification.cpp effedup.cpp)
-    target_compile_definitions(test_classification PRIVATE ${LIBLLKA_GLOBAL_DEFINITIONS} ${LIBLLKA_PLATFORM_DEFINITIONS} ${LLKA_STATIC_DEFINE})
+    target_compile_definitions(test_classification PRIVATE ${LIBLLKA_GLOBAL_DEFINITIONS} ${LIBLLKA_PLATFORM_DEFINITIONS})
     target_link_libraries(test_classification ${LLKA_LIB_LINK})
     add_test(NAME Classification COMMAND test_classification)
     # Get definition files necessary to initialize classification context
@@ -105,7 +103,7 @@ if ((NOT EMSCRIPTEN) OR (EMX_JS_BUILD_MODE STREQUAL "Node") OR (EMX_JS_BUILD_MOD
 
 
     add_executable(test_minicif test_minicif.cpp effedup.cpp)
-    target_compile_definitions(test_minicif PRIVATE ${LIBLLKA_GLOBAL_DEFINITIONS} ${LIBLLKA_PLATFORM_DEFINITIONS} ${LLKA_STATIC_DEFINE})
+    target_compile_definitions(test_minicif PRIVATE ${LIBLLKA_GLOBAL_DEFINITIONS} ${LIBLLKA_PLATFORM_DEFINITIONS})
     # Make sure that the test does not run out of memory when ran with Node.js
     if (EMSCRIPTEN)
         set_target_properties(
@@ -146,12 +144,12 @@ if ((NOT EMSCRIPTEN) OR (EMX_JS_BUILD_MODE STREQUAL "Node") OR (EMX_JS_BUILD_MOD
 endif ()
 
 add_executable(test_cpp_interface test_cpp_interface.cpp effedup.cpp)
-target_compile_definitions(test_cpp_interface PRIVATE ${LIBLLKA_GLOBAL_DEFINITIONS} ${LIBLLKA_PLATFORM_DEFINITIONS} ${LLKA_STATIC_DEFINE})
+target_compile_definitions(test_cpp_interface PRIVATE ${LIBLLKA_GLOBAL_DEFINITIONS} ${LIBLLKA_PLATFORM_DEFINITIONS})
 target_link_libraries(test_cpp_interface ${LLKA_LIB_LINK} ${CPP_EXTRA_LINK})
 add_test(NAME CppInterface COMMAND test_cpp_interface)
 
 add_executable(test_cpp_interface_2 test_cpp_interface_2.cpp effedup.cpp)
-target_compile_definitions(test_cpp_interface_2 PRIVATE ${LIBLLKA_GLOBAL_DEFINITIONS} ${LIBLLKA_PLATFORM_DEFINITIONS} ${LLKA_STATIC_DEFINE})
+target_compile_definitions(test_cpp_interface_2 PRIVATE ${LIBLLKA_GLOBAL_DEFINITIONS} ${LIBLLKA_PLATFORM_DEFINITIONS})
 add_test(NAME CppInterface2 COMMAND test_cpp_interface_2)
 if (EMSCRIPTEN)
     set_target_properties(
@@ -165,6 +163,6 @@ else ()
 endif ()
 
 add_executable(test_cpp_interface_3 test_cpp_interface_3.cpp effedup.cpp)
-target_compile_definitions(test_cpp_interface_3 PRIVATE ${LIBLLKA_GLOBAL_DEFINITIONS} ${LIBLLKA_PLATFORM_DEFINITIONS} ${LLKA_STATIC_DEFINE})
+target_compile_definitions(test_cpp_interface_3 PRIVATE ${LIBLLKA_GLOBAL_DEFINITIONS} ${LIBLLKA_PLATFORM_DEFINITIONS})
 add_test(NAME CppInterface3 COMMAND test_cpp_interface_3)
 target_link_libraries(test_cpp_interface_3 PRIVATE ${LLKA_LIB_LINK} ${CPP_EXTRA_LINK})


### PR DESCRIPTION
This PR cleans up some of the AI generated code to make the examples easier to read and follow.

- The platform-specific functionality are simplified and hidden in a header file
- Users of the library do not have to explicitly pass the LLKA_BUILD_STATIC preprocessor directive
- Code is buildable with MSVC
- Possible undefined behavior when calling MultiByteToWideChar is fixed