### PR TITLE
Make NtCStructure available through C++ API and exported to Emscripten

### DIFF
--- a/include/llka_cpp.h
+++ b/include/llka_cpp.h
@@ -762,6 +762,9 @@ auto nameToNtC(const std::string &name) noexcept -> LLKA_NtC;
 LLKA_CPP_API
 auto NtCToName(LLKA_NtC ntc) noexcept -> std::string;
 
+LLKA_CPP_API
+auto NtCStructure(LLKA_NtC ntc) noexcept -> Structure;
+
 using StepInfo = LLKA_StepInfo;
 LLKA_CPP_API
 auto structureIsStep(const Structure &stru) noexcept -> RCResult<LLKA_StepInfo>;
@@ -1530,6 +1533,7 @@ EMSCRIPTEN_BINDINGS(LLKA)
     emscripten::function("CANAToName", &LLKA::CANAToName);
     emscripten::function("nameToNtC", &LLKA::nameToNtC);
     emscripten::function("NtCToName", &LLKA::NtCToName);
+    emscripten::function("NtCStructure", &LLKA::NtCStructure);
     emscripten::function("structureIsStep", &LLKA::structureIsStep);
 
     //

--- a/include/llka_cpp.h
+++ b/include/llka_cpp.h
@@ -433,8 +433,17 @@ template <typename S> using RCResult = Result<S, LLKA_RetCode>;
 
 using Points = std::vector<LLKA_Point>; // TODO: Revise this when we figure out how to do memory alignment of point arrays
 
-class Matrix {
+class LLKA_CPP_API Matrix {
 public:
+#ifdef LLKA_PLATFORM_EMSCRIPTEN
+    Matrix() noexcept :
+        nCols{0},
+        nRows{0},
+        data{nullptr}
+    {
+    }
+#endif // LLKA_PLATFORM_EMSCRIPTEN
+
     explicit Matrix(LLKA_Matrix matrix) noexcept :
         nCols{matrix.nCols},
         nRows{matrix.nRows},
@@ -498,6 +507,18 @@ public:
 
         return *this;
     }
+
+#ifdef LLKA_PLATFORM_EMSCRIPTEN
+    auto _emsGet_nCols() const -> size_t
+    {
+        return nRows;
+    }
+
+    auto _emsGet_nRows() const -> size_t
+    {
+        return nRows;
+    }
+#endif // LLKA_PLATFORM_EMSCRIPTEN
 
 private:
     double *data;
@@ -1269,6 +1290,13 @@ template LLKA_CPP_API auto makeStdVector<int32_t>();
         .function("success", std::function<typename LLKA::ResultSuccessReturnType<S, std::is_copy_constructible_v<S>>::RT (LLKA::RCResult<S>&)>(&LLKA::RCResult<S>::success)) \
         .function("const_success", std::function<const S &(const LLKA::RCResult<S>&)>(&LLKA::RCResult<S>::const_success)) \
         .function("isSuccess", &LLKA::RCResult<S>::isSuccess)
+#define _EMX_MK_RCRESULT_VOID \
+    emscripten::class_<LLKA::RCResult<void>>("RCResult_void") \
+        .constructor() \
+        .constructor<LLKA_RetCode, bool>() \
+        .function("failure", &LLKA::RCResult<void>::failure) \
+        .function("isSuccess", &LLKA::RCResult<void>::isSuccess)
+
 
 EMSCRIPTEN_BINDINGS(LLKA)
 {
@@ -1278,6 +1306,16 @@ EMSCRIPTEN_BINDINGS(LLKA)
 
     emscripten::register_vector<std::string>("StringVector");
     emscripten::register_vector<int32_t>("Int32Vector");
+
+    // Note that this is just a partial implementation
+    // that is good enough to pass the Matrix object around
+    // in JS code as a mostly opaque entity
+    emscripten::class_<LLKA::Matrix>("Matrix")
+        .constructor<>()
+        .constructor<LLKA::Matrix &>()
+        _EMX_CLS_PROP_READONLY(nCols, LLKA::Matrix)
+        _EMX_CLS_PROP_READONLY(nRows, LLKA::Matrix)
+    ;
 
     emscripten::enum_<LLKA_RetCode>("RetCode")
         _EMX_ENUM_VAL(LLKA_OK)
@@ -1300,6 +1338,8 @@ EMSCRIPTEN_BINDINGS(LLKA)
     ;
 
     emscripten::function("errorToString", &LLKA::errorToString);
+
+    _EMX_MK_RCRESULT_VOID;
 
     //
     // Structure
@@ -1364,13 +1404,23 @@ EMSCRIPTEN_BINDINGS(LLKA)
     //
 
     _EMX_MK_RCRESULT(double);
+    _EMX_MK_RCRESULT(LLKA::Matrix);
 
     emscripten::function("centroidPoints", emscripten::select_overload<LLKA_Point(const LLKA::Points&)>(&LLKA::centroid));
     emscripten::function("centroidStructure", emscripten::select_overload<LLKA_Point(const LLKA::Structure&)>(&LLKA::centroid));
     emscripten::function("rmsdPoints", emscripten::select_overload<LLKA::RCResult<double>(const LLKA::Points&, const LLKA::Points&)>(&LLKA::rmsd));
     emscripten::function("rmsd", emscripten::select_overload<LLKA::RCResult<double>(const LLKA::Structure&, const LLKA::Structure&)>(&LLKA::rmsd));
-    emscripten::function("superposePoints", emscripten::select_overload<LLKA::RCResult<double>(LLKA::Points&, const LLKA::Points &)>(&LLKA::superpose));
+
+    emscripten::function("applyTransformationPoints", emscripten::select_overload<LLKA::RCResult<void>(LLKA::Points&, const LLKA::Matrix&)>(&LLKA::applyTransformation));
+    emscripten::function("applyTransformationStructure", emscripten::select_overload<LLKA::RCResult<void>(LLKA::Structure&, const LLKA::Matrix&)>(&LLKA::applyTransformation));
+
     emscripten::function("superposeStructures", emscripten::select_overload<LLKA::RCResult<double>(LLKA::Structure &, const LLKA::Structure &)>(&LLKA::superpose));
+    emscripten::function("superposePoints", emscripten::select_overload<LLKA::RCResult<double>(LLKA::Points&, const LLKA::Points &)>(&LLKA::superpose));
+
+    emscripten::function("superpositionMatrixPoints", emscripten::select_overload<LLKA::RCResult<LLKA::Matrix>(LLKA::Points&, const LLKA::Points&)>(&LLKA::superpositionMatrix));
+    emscripten::function("superpositionMatrixStructures", emscripten::select_overload<LLKA::RCResult<LLKA::Matrix>(LLKA::Structure&, const LLKA::Structure&)>(&LLKA::superpositionMatrix));
+    emscripten::function("superpositionMatrixStructureViews", emscripten::select_overload<LLKA::RCResult<LLKA::Matrix>(LLKA::StructureView&, const LLKA::StructureView&)>(&LLKA::superpositionMatrix));
+
     emscripten::function("splitByAltIds", &LLKA::splitByAltIds);
     emscripten::function("splitStructureToDinucleotideSteps", &LLKA::splitStructureToDinucleotideSteps);
 
@@ -1590,9 +1640,11 @@ EMSCRIPTEN_BINDINGS(LLKA)
     ;
 
     _EMX_MK_RCRESULT(LLKA_StepInfo);
+    _EMX_MK_RCRESULT(LLKA_StepMetrics);
 
     emscripten::function("backboneAtomIndex", &LLKA::backboneAtomIndex);
     emscripten::function("calculateStepMetrics", &LLKA::calculateStepMetrics);
+    emscripten::function("calculateStepMetricsDifferenceAgainstReference", &LLKA::calculateStepMetricsDifferenceAgainstReference);
     emscripten::function("crossResidueMetric", &LLKA::crossResidueMetric);
     emscripten::function(
         "crossResidueMetricAtomsFromBases",

--- a/include/llka_cpp.h
+++ b/include/llka_cpp.h
@@ -236,7 +236,6 @@ private:
     bool m_isSuccess;
     bool m_movedAway;
 };
-template <typename S> using RCResult = Result<S, LLKA_RetCode>;
 
 template <typename F>
 class Result<void, F> {
@@ -304,7 +303,7 @@ public:
 
         if (m_isSuccess)
             throw std::runtime_error{"Cannot get failed value for a succesful result"};
-        return failure;
+        return m_failure;
     }
 
     bool isSuccess() const
@@ -426,11 +425,84 @@ private:
     bool m_movedAway;
 };
 
+template <typename S> using RCResult = Result<S, LLKA_RetCode>;
+
 //
 // Main
 //
 
 using Points = std::vector<LLKA_Point>; // TODO: Revise this when we figure out how to do memory alignment of point arrays
+
+class Matrix {
+public:
+    explicit Matrix(LLKA_Matrix matrix) noexcept :
+        nCols{matrix.nCols},
+        nRows{matrix.nRows},
+        data{matrix.data}
+    {
+    }
+
+    explicit Matrix(double *data, size_t nRows, size_t nCols) noexcept :
+        nCols{nCols},
+        nRows{nRows},
+        data{data}
+    {
+    }
+
+    // Impl is in llka_cpp.cpp
+    Matrix(const Matrix &other) noexcept;
+
+    Matrix(Matrix &&other) noexcept :
+        nCols{other.nCols},
+        nRows{other.nRows},
+        data{other.data}
+    {
+        other.data = nullptr;
+    }
+
+    // Impl is in llka_cpp.cpp
+    ~Matrix() noexcept;
+
+    const size_t nCols;
+    const size_t nRows;
+
+    operator LLKA_Matrix() noexcept
+    {
+        LLKA_Matrix m{ data, nRows, nCols };
+        return m;
+    }
+
+    operator const LLKA_Matrix() const noexcept
+    {
+        LLKA_Matrix m{ data, nRows, nCols };
+        return m;
+    }
+
+    auto operator()(size_t row, size_t col) noexcept -> double
+    {
+        assert(row < nRows && col < nCols && "Attempted to get a matrix element that is outside the matrix dimensions");
+
+        return data[nRows * col + row];
+    }
+
+    // Impl is in llka_cpp.cpp
+    auto operator=(const Matrix &other) noexcept -> Matrix;
+
+    auto operator=(Matrix &&other) noexcept -> Matrix
+    {
+        const_cast<size_t&>(this->nCols) = other.nCols;
+        const_cast<size_t&>(this->nRows) = other.nRows;
+        this->data = other.data;
+
+        other.data = nullptr;
+
+        return *this;
+    }
+
+private:
+    double *data;
+
+};
 
 LLKA_CPP_API
 auto operator<<(std::ostream &os, const LLKA_Point &pt) -> std::ostream &;
@@ -573,6 +645,12 @@ auto measureDistance(const Atom &a, const Atom &b) -> T;
 //
 
 LLKA_CPP_API
+auto applyTransformation(Points &what, const Matrix &matrix) noexcept -> RCResult<void>;
+
+LLKA_CPP_API
+auto applyTransformation(Structure &what, const Matrix &matrix) noexcept -> RCResult<void>;
+
+LLKA_CPP_API
 auto centroid(const Points &points) noexcept -> LLKA_Point;
 
 LLKA_CPP_API
@@ -589,6 +667,15 @@ auto superpose(Points &what, const Points &onto) noexcept -> RCResult<double>;
 
 LLKA_CPP_API
 auto superpose(Structure &what, const Structure &onto) noexcept -> RCResult<double>;
+
+LLKA_CPP_API
+auto superpositionMatrix(Structure &what, const Structure &onto) noexcept -> RCResult<Matrix>;
+
+LLKA_CPP_API
+auto superpositionMatrix(Points &what, const Points &onto) noexcept -> RCResult<Matrix>;
+
+LLKA_CPP_API
+auto superpositionMatrix(StructureView &what, const StructureView &onto) noexcept -> RCResult<Matrix>;
 
 //
 // Segmentation

--- a/include/llka_main.h
+++ b/include/llka_main.h
@@ -169,6 +169,15 @@ LLKA_API const char * LLKA_CC LLKA_errorToString(LLKA_RetCode tRet);
 LLKA_API void LLKA_CC LLKA_initMatrix(size_t rows, size_t columns, LLKA_Matrix *matrix);
 
 /*!
+ * Duplicates a matrix
+ *
+ * @param[in] Matrix to duplicate
+ *
+ * @returns Duplicated matrix
+ */
+LLKA_API LLKA_Matrix LLKA_CC LLKA_duplicateMatrix(const LLKA_Matrix *matrix);
+
+/*!
  * Creates \p LLKA_Points structure from array of \p LLKA_Point s. The returned \p LLKA_Points contains copies of the input points.
  *
  * @param[in] points Array of \p LLKA_Point s

--- a/src/llka.cpp
+++ b/src/llka.cpp
@@ -18,6 +18,16 @@ void LLKA_CC LLKA_initMatrix(size_t rows, size_t cols, LLKA_Matrix *matrix)
     matrix->nCols = cols;
 }
 
+LLKA_Matrix LLKA_CC LLKA_duplicateMatrix(const LLKA_Matrix *matrix)
+{
+    LLKA_Matrix dup;
+    LLKA_initMatrix(matrix->nRows, matrix->nCols, &dup);
+
+    std::memcpy(dup.data, matrix->data, sizeof(double) * matrix->nRows * matrix->nCols);
+
+    return dup;
+}
+
 void LLKA_CC LLKA_destroyPoints(const LLKA_Points *points)
 {
     delete [] points->points;

--- a/src/llka_cpp.cpp
+++ b/src/llka_cpp.cpp
@@ -17,6 +17,7 @@
 #include <util/geometry.h>
 
 #include <algorithm>
+#include <cassert>
 #include <cstring>
 #include <memory>
 #include <ostream>
@@ -88,6 +89,42 @@ auto operator<<(std::ostream &os, const LLKA_Point &pt) -> std::ostream &
 {
     os << "[ " << pt.x << "; " << pt.y << "; " << pt.z << " ]";
     return os;
+}
+
+LLKA_CPP_API
+Matrix::Matrix(const Matrix &other) noexcept :
+    nCols{other.nCols},
+    nRows{other.nRows}
+{
+    LLKA_Matrix m{ other.data, other.nRows, other.nCols };
+
+    auto dup = LLKA_duplicateMatrix(&m);
+    this->data = dup.data;
+}
+
+LLKA_CPP_API
+Matrix::~Matrix() noexcept
+{
+    if (data == nullptr) return;
+
+    // We have taken ownership of the data that originally was in the LLKA_Matrix object.
+    // We need to re-create a dummy LLKA_Matrix object again to pass it to the destructor
+    // for cleanup
+    LLKA_Matrix m{ data, nRows, nCols };
+    LLKA_destroyMatrix(&m);
+}
+
+LLKA_CPP_API
+auto Matrix::operator=(const Matrix &other) noexcept -> Matrix
+{
+    LLKA_Matrix m{ other.data, other.nRows, other.nCols };
+
+    auto dup = LLKA_duplicateMatrix(&m);
+    const_cast<size_t&>(this->nCols) = dup.nCols;
+    const_cast<size_t&>(this->nRows) = dup.nRows;
+    this->data = dup.data;
+
+    return *this;
 }
 
 auto errorToString(LLKA_RetCode tRet) -> std::string
@@ -368,6 +405,37 @@ template LLKA_CPP_API auto measureDistance<long double>(const Atom &a, const Ato
 // Superposition
 //
 
+auto applyTransformation(Points &what, const Matrix &matrix) noexcept -> RCResult<void>
+{
+    LLKA_Points cWhat{
+        { what.data() },
+        what.size()
+    };
+    LLKA_Matrix cMatrix = matrix;
+
+    auto tRet = LLKA_applyTransformationPoints(&cWhat, &cMatrix);
+    if (tRet != LLKA_OK)
+        return RCResult<void>::fail(tRet);
+
+    return RCResult<void>::succeed();
+}
+
+auto applyTransformation(Structure &what, const Matrix &matrix) noexcept -> RCResult<void>
+{
+    auto wWhat = helpers::struToWrappedCStru(what);
+    LLKA_Matrix cMatrix = matrix;
+
+    auto tRet = LLKA_applyTransformationStructure(&wWhat.cStru, &cMatrix);
+    if (tRet != LLKA_OK)
+        return RCResult<void>::fail(tRet);
+
+    // Map the results back
+    for (size_t idx = 0; idx < what.size(); idx++)
+        what[idx].coords = wWhat.cAtoms[idx].coords;
+
+    return RCResult<void>::succeed();
+}
+
 auto centroid(const Points &points) noexcept -> LLKA_Point
 {
     // TODO: We are mapping the points vector memory directly onto
@@ -453,6 +521,54 @@ auto superpose(Structure &what, const Structure &onto) noexcept -> RCResult<doub
         what[idx].coords = wWhat.cAtoms[idx].coords;
 
     return RCResult<double>::succeed(rmsd);
+}
+
+auto superpositionMatrix(Points &what, const Points &onto) noexcept -> RCResult<Matrix>
+{
+    LLKA_Points cWhat{
+        { what.data() },
+        what.size()
+    };
+    const LLKA_Points cOnto{
+        { const_cast<LLKA_Point *>(onto.data()) },   // LLKA_Points expects mutable array
+        onto.size()
+    };
+
+    LLKA_Matrix cMatrix;
+    auto tRet = LLKA_superpositionMatrixPoints(&cWhat, &cOnto, &cMatrix);
+    if (tRet != LLKA_OK)
+        return RCResult<Matrix>::fail(tRet);
+
+    auto matrix = Matrix(cMatrix);
+    return RCResult<Matrix>::succeed(std::move(matrix));
+}
+
+auto superpositionMatrix(Structure &what, const Structure &onto) noexcept -> RCResult<Matrix>
+{
+    auto wWhat = helpers::struToWrappedCStru(what);
+    const auto wOnto = helpers::struToWrappedCStru(onto);
+
+    LLKA_Matrix cMatrix;
+    auto tRet = LLKA_superpositionMatrixStructures(&wWhat.cStru, &wOnto.cStru, &cMatrix);
+    if (tRet != LLKA_OK)
+        return RCResult<Matrix>::fail(tRet);
+
+    auto matrix = Matrix(cMatrix);
+    return RCResult<Matrix>::succeed(std::move(matrix));
+}
+
+auto superpositionMatrix(StructureView &what, const StructureView &onto) noexcept -> RCResult<Matrix>
+{
+    auto wWhat = helpers::struViewToWrappedCStru(what);
+    const auto wOnto = helpers::struViewToWrappedCStru(onto);
+
+    LLKA_Matrix cMatrix;
+    auto tRet = LLKA_superpositionMatrixStructures(&wWhat.cStru, &wOnto.cStru, &cMatrix);
+    if (tRet != LLKA_OK)
+        return RCResult<Matrix>::fail(tRet);
+
+    auto matrix = Matrix(cMatrix);
+    return RCResult<Matrix>::succeed(std::move(matrix));
 }
 
 #ifdef LLKA_PLATFORM_EMSCRIPTEN

--- a/src/llka_cpp.cpp
+++ b/src/llka_cpp.cpp
@@ -747,6 +747,15 @@ auto NtCToName(LLKA_NtC ntc) noexcept -> std::string
     return LLKA_NtCToName(ntc);
 }
 
+auto NtCStructure(LLKA_NtC ntc) noexcept -> Structure
+{
+    auto cStru = LLKA_NtCStructure(ntc);
+    auto stru = makeStructure(cStru.atoms, cStru.nAtoms);
+    LLKA_destroyStructure(&cStru);
+
+    return stru;
+}
+
 auto structureIsStep(const Structure &stru) noexcept -> RCResult<LLKA_StepInfo>
 {
     const auto wStru = helpers::struToWrappedCStru(stru);

--- a/tests/test_cpp_interface.cpp
+++ b/tests/test_cpp_interface.cpp
@@ -280,6 +280,52 @@ auto superposition_testStructure()
 }
 
 static
+auto superposition_testStructureWithExplicitMatrix()
+{
+    LLKA::Structure ref_AB01 = LLKA::makeStructure(REF_AB01_ATOMS, REF_AB01_ATOMS_LEN);
+    LLKA::Structure real_AB01 = LLKA::makeStructure(REAL_1BNA_A_3_4_ATOMS, REAL_1BNA_A_3_4_ATOMS_LEN);
+
+    auto tRet = LLKA::extractBackbone(ref_AB01);
+    EFF_expect(tRet.isSuccess(), true, "LLKA_extractBackbone() returned unexpected value " + LLKA::errorToString(tRet.failure()))
+    auto ref_AB01_bkbn = tRet.success();
+
+    tRet = LLKA::extractBackbone(real_AB01);
+    EFF_expect(tRet.isSuccess(), true, "LLKA_extractBackbone() returned unexpected value " + LLKA::errorToString(tRet.failure()));
+    auto real_AB01_bkbn = tRet.success();
+
+    auto tRet2 = LLKA::superpositionMatrix(real_AB01_bkbn, ref_AB01_bkbn);
+    EFF_expect(tRet2.isSuccess(), true, "LLKA_superpositionMatrix() returned unexpected value " + LLKA::errorToString(tRet2.failure()))
+    auto matrix = tRet2.success();
+
+    auto tRet3 = LLKA::applyTransformation(real_AB01_bkbn, matrix);
+    EFF_expect(tRet3.isSuccess(), true, "LLKA_applyTransformation() returned unexpected value " + LLKA::errorToString(tRet3.failure()))
+
+    LLKA::Points expected{
+        { 0.950860168366356, -4.10490242639581, 1.88352814333396 },
+        { 0.50054990344796, -3.69993907500445, 0.514678133530478 },
+        { -0.347244679657512, -4.71592059085125, -0.00580232173625572 },
+        { -0.318861255763144, -2.43716579580966, 0.473326017357792 },
+        { 0.506320258152502, -1.32662194302102, 0.113179074950623 },
+        { -0.0811260469759572, 0.154118620506023, 0.0681432878857751},
+        { -0.647318283320744, 0.253840078930681, -1.40665838767353 },
+        { 0.237737393186242, 0.145726060576478, -2.52768907793944 },
+        { -0.603024580420967, 0.282861734520597, -3.76182161161158 },
+        { -1.56591988716846, -0.783314033669751, -3.80479671565305 },
+        { -1.41697603269085, 1.56517005180424, -3.86385794226367 },
+        { -1.71799695715546, 1.88014731841389, -5.20722860018113 }
+    };
+
+    for (size_t idx = 0; idx < 12; idx++)
+        CHECK_POINT(real_AB01_bkbn[idx].coords, expected[idx]);
+
+    auto tRet4 = LLKA::rmsd(real_AB01_bkbn, ref_AB01_bkbn);
+    EFF_expect(tRet4.isSuccess(), true, "LLKA_rmsd() returned unexpected value " + LLKA::errorToString(tRet4.failure()))
+    auto rmsd = tRet4.success();
+
+    EFF_cmpFlt(rmsd, 0.147657613575976, "RMSD is wrong");
+}
+
+static
 auto connectivity_testConnectivity()
 {
     // Test based on results for 1BNA molecule
@@ -398,6 +444,7 @@ auto main() -> int
 
     superposition_testShifted();
     superposition_testStructure();
+    superposition_testStructureWithExplicitMatrix();
 
     NtC_testExtractPlainBackbone();
     NtC_testExtractExtendedBackbone();


### PR DESCRIPTION
Make additional parts of the C++ interface available to Emscripten. It is now needed to implement NtC in Moorhen.