### PR TITLE
Deal with incomplete and partially broken Cif inputs

### DIFF
--- a/include/llka_minicif.h
+++ b/include/llka_minicif.h
@@ -9,7 +9,8 @@
 enum {
     LLKA_MINICIF_NORMALIZE               = (1 << 0),    /*!< Attempt to sort imported structure by model, chain and sequence id */
     LLKA_MINICIF_GET_CIFDATA             = (1 << 1),    /*!< Export complete processed Cif data */
-    LLKA_MINICIF_ALLOW_NO_ENTRY_CATEGORY = (1 << 2)     /*!< Tolerate Cif data that do not have any "entry" categories */
+    LLKA_MINICIF_ALLOW_NO_ENTRY_CATEGORY = (1 << 2),    /*!< Tolerate Cif data that do not have any "entry" categories */
+    LLKA_MINICIF_ALLOW_BROKEN_ATOMSITE   = (1 << 3)     /*!< Tolerate atom_site with missing mandatory fields and make the best effort top fix them up */
 };
 
 typedef struct LLKA_CifData LLKA_CifData;

--- a/include/llka_minicif.h
+++ b/include/llka_minicif.h
@@ -7,8 +7,9 @@
 
 /*! Flags that control import behavior. */
 enum {
-    LLKA_MINICIF_NORMALIZE   = (1 << 0),    /*!< Attempt to sort imported structure by model, chain and sequence id */
-    LLKA_MINICIF_GET_CIFDATA = (1 << 1)     /*!< Export complete processed Cif data */
+    LLKA_MINICIF_NORMALIZE               = (1 << 0),    /*!< Attempt to sort imported structure by model, chain and sequence id */
+    LLKA_MINICIF_GET_CIFDATA             = (1 << 1),    /*!< Export complete processed Cif data */
+    LLKA_MINICIF_ALLOW_NO_ENTRY_CATEGORY = (1 << 2)     /*!< Tolerate Cif data that do not have any "entry" categories */
 };
 
 typedef struct LLKA_CifData LLKA_CifData;

--- a/src/minicif.cpp
+++ b/src/minicif.cpp
@@ -167,6 +167,73 @@ auto toCifData(const std::vector<Block> &blocks)
 }
 
 static
+auto processAtomSite(const std::vector<MiniCif::Block> &blocks)
+{
+    auto fixupAtom = [](LLKA_Atom &atom) {
+        if (atom.auth_atom_id == nullptr)
+            atom.auth_atom_id = LLKAInternal::duplicateString(atom.label_atom_id);
+        if (atom.auth_comp_id == nullptr)
+            atom.auth_comp_id = LLKAInternal::duplicateString(atom.label_comp_id);
+        if (atom.auth_asym_id == nullptr)
+            atom.auth_asym_id = LLKAInternal::duplicateString(atom.label_asym_id);
+        if (atom.pdbx_PDB_ins_code == nullptr)
+            atom.pdbx_PDB_ins_code = LLKAInternal::duplicateString(LLKA_NO_INSCODE);
+    };
+
+    return LLKAInternal::MiniCif::Applier<LLKAInternal::MiniCif::Categories::AtomSite>::apply(
+        blocks[0],
+        fixupAtom,
+        [](const LLKA_Atom &atom) { LLKA_destroyAtom(&atom); }
+    );
+}
+
+static
+auto processAtomSiteAllowBroken(const std::vector<MiniCif::Block> &blocks)
+{
+    auto fixupAtom = [](LLKA_Atom &atom) {
+        // If we have data in the auth_ fields but not in the label_ fields,
+        // copy the data from auth_ to label_. Otherwise just keep the label_
+        // fields empty, even though this pretty much renders the resulting
+        // structure unusable
+        if (atom.label_atom_id == nullptr) {
+            if (atom.auth_atom_id == nullptr) {
+                atom.auth_atom_id = LLKAInternal::duplicateString("");
+            }
+            atom.label_atom_id = LLKAInternal::duplicateString(atom.auth_atom_id);
+        }
+        if (atom.label_comp_id == nullptr) {
+            if (atom.auth_comp_id == nullptr) {
+                atom.auth_comp_id = LLKAInternal::duplicateString("");
+            }
+            atom.label_comp_id = LLKAInternal::duplicateString(atom.auth_comp_id);
+        }
+        if (atom.label_asym_id == nullptr) {
+            if (atom.auth_asym_id == nullptr) {
+                atom.auth_asym_id = LLKAInternal::duplicateString("");
+            }
+            atom.label_asym_id = LLKAInternal::duplicateString(atom.auth_asym_id);
+        }
+
+        // Now do the standard fixup where we fill out the auth_ data from label_
+        // data.
+        if (atom.auth_atom_id == nullptr)
+            atom.auth_atom_id = LLKAInternal::duplicateString(atom.label_atom_id);
+        if (atom.auth_comp_id == nullptr)
+            atom.auth_comp_id = LLKAInternal::duplicateString(atom.label_comp_id);
+        if (atom.auth_asym_id == nullptr)
+            atom.auth_asym_id = LLKAInternal::duplicateString(atom.label_asym_id);
+        if (atom.pdbx_PDB_ins_code == nullptr)
+            atom.pdbx_PDB_ins_code = LLKAInternal::duplicateString(LLKA_NO_INSCODE);
+    };
+
+    return LLKAInternal::MiniCif::Applier<LLKAInternal::MiniCif::Categories::AtomSite_AllowBroken>::apply(
+        blocks[0],
+        fixupAtom,
+        [](const LLKA_Atom &atom) { LLKA_destroyAtom(&atom); }
+    );
+}
+
+static
 auto toStructure(const std::string_view &view, LLKA_ImportedStructure *importedStru, char **error, int32_t options)
 {
     try {
@@ -191,23 +258,11 @@ auto toStructure(const std::string_view &view, LLKA_ImportedStructure *importedS
             entryId = entries[0].id;
         }
 
-        auto fixupAtom = [](LLKA_Atom &atom) {
-            if (atom.label_asym_id == nullptr)
-                atom.label_asym_id = LLKAInternal::duplicateString("");
-            if (atom.auth_atom_id == nullptr)
-                atom.auth_atom_id = LLKAInternal::duplicateString(atom.label_atom_id);
-            if (atom.auth_comp_id == nullptr)
-                atom.auth_comp_id = LLKAInternal::duplicateString(atom.label_comp_id);
-            if (atom.auth_asym_id == nullptr)
-                atom.auth_asym_id = LLKAInternal::duplicateString(atom.label_asym_id);
-            if (atom.pdbx_PDB_ins_code == nullptr)
-                atom.pdbx_PDB_ins_code = LLKAInternal::duplicateString(LLKA_NO_INSCODE);
-        };
-        auto [ atoms, nAtoms ] = LLKAInternal::MiniCif::Applier<LLKAInternal::MiniCif::Categories::AtomSite>::apply(
-            blocks[0],
-            fixupAtom,
-            [](const LLKA_Atom &atom) { LLKA_destroyAtom(&atom); }
-        );
+        bool allowBrokenAtomSite = options & LLKA_MINICIF_ALLOW_BROKEN_ATOMSITE;
+
+        auto [ atoms, nAtoms ] = allowBrokenAtomSite
+            ? processAtomSiteAllowBroken(blocks)
+            : processAtomSite(blocks);
 
         if (options & LLKA_MINICIF_NORMALIZE)
             LLKAInternal::MiniCif::normalize(atoms, nAtoms);

--- a/src/minicif.cpp
+++ b/src/minicif.cpp
@@ -236,6 +236,8 @@ auto processAtomSiteAllowBroken(const std::vector<MiniCif::Block> &blocks)
 static
 auto toStructure(const std::string_view &view, LLKA_ImportedStructure *importedStru, char **error, int32_t options)
 {
+    std::memset(importedStru, 0, sizeof(LLKA_ImportedStructure));
+
     try {
         auto blocks = parse(view);
 
@@ -248,14 +250,13 @@ auto toStructure(const std::string_view &view, LLKA_ImportedStructure *importedS
             (options & LLKA_MINICIF_ALLOW_NO_ENTRY_CATEGORY) > 0
         );
 
-        const char *entryId;
         if (nEntries < 1) {
             if (!(options & LLKA_MINICIF_ALLOW_NO_ENTRY_CATEGORY))
                 return LLKA_E_BAD_DATA;
 
-            entryId = LLKAInternal::duplicateString("");
+            importedStru->entry.id = LLKAInternal::duplicateString("");
         } else {
-            entryId = entries[0].id;
+            importedStru->entry.id = entries[0].id;
         }
 
         bool allowBrokenAtomSite = options & LLKA_MINICIF_ALLOW_BROKEN_ATOMSITE;
@@ -267,7 +268,6 @@ auto toStructure(const std::string_view &view, LLKA_ImportedStructure *importedS
         if (options & LLKA_MINICIF_NORMALIZE)
             LLKAInternal::MiniCif::normalize(atoms, nAtoms);
 
-        importedStru->entry.id = entryId;
         importedStru->structure.atoms = atoms.release();
         importedStru->structure.nAtoms = nAtoms;
 
@@ -280,12 +280,16 @@ auto toStructure(const std::string_view &view, LLKA_ImportedStructure *importedS
 
         return LLKA_OK;
     } catch (const LLKAInternal::MiniCif::CifParseError &ex) {
+        LLKA_destroyString(importedStru->entry.id);
+
         const auto len = std::strlen(ex.what());
         *error = new char[len + 1];
         std::strcpy(*error, ex.what());
 
         return LLKA_E_BAD_DATA;
     } catch (const LLKAInternal::MiniCif::CifSchemaError &ex) {
+        LLKA_destroyString(importedStru->entry.id);
+
         const auto len = std::strlen(ex.what());
         *error = new char[len + 1];
         std::strcpy(*error, ex.what());

--- a/src/minicif.cpp
+++ b/src/minicif.cpp
@@ -174,16 +174,26 @@ auto toStructure(const std::string_view &view, LLKA_ImportedStructure *importedS
 
         // TODO: We should look into the potential memory leaks here if we get unexpected data
 
-        auto [ entires, nEntries ] = LLKAInternal::MiniCif::Applier<LLKAInternal::MiniCif::Categories::Entry>::apply(
+        auto [ entries, nEntries ] = LLKAInternal::MiniCif::Applier<LLKAInternal::MiniCif::Categories::Entry>::apply(
             blocks[0],
             NoopFixup<LLKA_StructureEntry>,
-            [](const LLKA_StructureEntry &e) { LLKAInternal::destroyString(e.id);
-        });
+            [](const LLKA_StructureEntry &e) { LLKAInternal::destroyString(e.id); },
+            (options & LLKA_MINICIF_ALLOW_NO_ENTRY_CATEGORY) > 0
+        );
 
-        if (nEntries < 1)
-            return LLKA_E_BAD_DATA;
+        const char *entryId;
+        if (nEntries < 1) {
+            if (!(options & LLKA_MINICIF_ALLOW_NO_ENTRY_CATEGORY))
+                return LLKA_E_BAD_DATA;
+
+            entryId = LLKAInternal::duplicateString("");
+        } else {
+            entryId = entries[0].id;
+        }
 
         auto fixupAtom = [](LLKA_Atom &atom) {
+            if (atom.label_asym_id == nullptr)
+                atom.label_asym_id = LLKAInternal::duplicateString("");
             if (atom.auth_atom_id == nullptr)
                 atom.auth_atom_id = LLKAInternal::duplicateString(atom.label_atom_id);
             if (atom.auth_comp_id == nullptr)
@@ -202,7 +212,7 @@ auto toStructure(const std::string_view &view, LLKA_ImportedStructure *importedS
         if (options & LLKA_MINICIF_NORMALIZE)
             LLKAInternal::MiniCif::normalize(atoms, nAtoms);
 
-        importedStru->entry.id = entires[0].id;
+        importedStru->entry.id = entryId;
         importedStru->structure.atoms = atoms.release();
         importedStru->structure.nAtoms = nAtoms;
 
@@ -215,6 +225,12 @@ auto toStructure(const std::string_view &view, LLKA_ImportedStructure *importedS
 
         return LLKA_OK;
     } catch (const LLKAInternal::MiniCif::CifParseError &ex) {
+        const auto len = std::strlen(ex.what());
+        *error = new char[len + 1];
+        std::strcpy(*error, ex.what());
+
+        return LLKA_E_BAD_DATA;
+    } catch (const LLKAInternal::MiniCif::CifSchemaError &ex) {
         const auto len = std::strlen(ex.what());
         *error = new char[len + 1];
         std::strcpy(*error, ex.what());

--- a/src/minicif/categories/atom-site.hpp
+++ b/src/minicif/categories/atom-site.hpp
@@ -30,6 +30,29 @@ using AtomSite = Schema<
 	TagValue<"label_atom_id", LLKA_AtomSetter<const char *, &LLKA_Atom::label_atom_id>>,
 	TagValue<"label_entity_id", LLKA_AtomSetter<const char *, &LLKA_Atom::label_entity_id>>,
 	TagValue<"label_comp_id", LLKA_AtomSetter<const char *, &LLKA_Atom::label_comp_id>>,
+	TagValue<"label_asym_id", LLKA_AtomSetter<const char *, &LLKA_Atom::label_asym_id>>,
+	TagValue<"auth_atom_id", LLKA_AtomSetter<const char *, &LLKA_Atom::auth_atom_id>, DefaultValue<const char *, nullptr>>, // Fix up later
+	TagValue<"auth_comp_id", LLKA_AtomSetter<const char *, &LLKA_Atom::auth_comp_id>, DefaultValue<const char *, nullptr>>, // Fix up later
+	TagValue<"auth_asym_id", LLKA_AtomSetter<const char *, &LLKA_Atom::auth_asym_id>, DefaultValue<const char *, nullptr>>, // Fix up later
+	TagValue<"cartn_x", LLKA_AtomCoordsSetter<&LLKA_Point::x>>,
+	TagValue<"cartn_y", LLKA_AtomCoordsSetter<&LLKA_Point::y>>,
+	TagValue<"cartn_z", LLKA_AtomCoordsSetter<&LLKA_Point::z>>,
+	TagValue<"label_seq_id", LLKA_AtomSetter<int32_t, &LLKA_Atom::label_seq_id>, DefaultValue<int32_t, 0>>,
+	TagValue<"auth_seq_id", LLKA_AtomSetter<int32_t, &LLKA_Atom::auth_seq_id>>,
+	TagValue<"pdbx_pdb_model_num", LLKA_AtomSetter<int32_t, &LLKA_Atom::pdbx_PDB_model_num>, DefaultValue<int32_t, 1>>,
+	TagValue<"pdbx_pdb_ins_code", LLKA_AtomSetter<const char *, &LLKA_Atom::pdbx_PDB_ins_code>, DefaultValue<const char *, nullptr>>, // Fix up later
+	TagValue<"label_alt_id", LLKA_AtomSetter<char, &LLKA_Atom::label_alt_id>, DefaultValue<char, LLKA_NO_ALTID>>
+>;
+
+using AtomSite_AllowBroken = Schema<
+	"atom_site",
+	LLKA_Atom,
+	//TagValue<"group_PDB", LLKA_StructureSetter<typename _Type, _Type LLKA_Structure::*Field>
+	TagValue<"id", LLKA_AtomSetter<uint32_t, &LLKA_Atom::id>>,
+	TagValue<"type_symbol", LLKA_AtomSetter<const char *, &LLKA_Atom::type_symbol>>,
+	TagValue<"label_atom_id", LLKA_AtomSetter<const char *, &LLKA_Atom::label_atom_id>, DefaultValue<const char *, nullptr>>, // Fix up later
+	TagValue<"label_entity_id", LLKA_AtomSetter<const char *, &LLKA_Atom::label_entity_id>>,
+	TagValue<"label_comp_id", LLKA_AtomSetter<const char *, &LLKA_Atom::label_comp_id>, DefaultValue<const char *, nullptr>>, // Fix up later
 	TagValue<"label_asym_id", LLKA_AtomSetter<const char *, &LLKA_Atom::label_asym_id>, DefaultValue<const char *, nullptr>>, // Fix up later
 	TagValue<"auth_atom_id", LLKA_AtomSetter<const char *, &LLKA_Atom::auth_atom_id>, DefaultValue<const char *, nullptr>>, // Fix up later
 	TagValue<"auth_comp_id", LLKA_AtomSetter<const char *, &LLKA_Atom::auth_comp_id>, DefaultValue<const char *, nullptr>>, // Fix up later

--- a/src/minicif/categories/atom-site.hpp
+++ b/src/minicif/categories/atom-site.hpp
@@ -30,7 +30,7 @@ using AtomSite = Schema<
 	TagValue<"label_atom_id", LLKA_AtomSetter<const char *, &LLKA_Atom::label_atom_id>>,
 	TagValue<"label_entity_id", LLKA_AtomSetter<const char *, &LLKA_Atom::label_entity_id>>,
 	TagValue<"label_comp_id", LLKA_AtomSetter<const char *, &LLKA_Atom::label_comp_id>>,
-	TagValue<"label_asym_id", LLKA_AtomSetter<const char *, &LLKA_Atom::label_asym_id>>,
+	TagValue<"label_asym_id", LLKA_AtomSetter<const char *, &LLKA_Atom::label_asym_id>, DefaultValue<const char *, nullptr>>, // Fix up later
 	TagValue<"auth_atom_id", LLKA_AtomSetter<const char *, &LLKA_Atom::auth_atom_id>, DefaultValue<const char *, nullptr>>, // Fix up later
 	TagValue<"auth_comp_id", LLKA_AtomSetter<const char *, &LLKA_Atom::auth_comp_id>, DefaultValue<const char *, nullptr>>, // Fix up later
 	TagValue<"auth_asym_id", LLKA_AtomSetter<const char *, &LLKA_Atom::auth_asym_id>, DefaultValue<const char *, nullptr>>, // Fix up later

--- a/src/minicif/schema.hpp
+++ b/src/minicif/schema.hpp
@@ -229,6 +229,8 @@ public:
 		bool allowNoCategory = false
 	)
 	{
+		LLKA_IS_POD(typename Schema::Image);
+
 		auto catIt = std::find_if(block.categories.cbegin(), block.categories.cend(), [](const Category &c) { return c.lowecaseName == Schema::name; });
 		if (catIt == block.categories.cend()) {
 			if (allowNoCategory) {
@@ -251,6 +253,10 @@ public:
 			throw CifSchemaError{"Category contains no values"};
 
 		auto items = std::unique_ptr<typename Schema::Image[]>(new typename Schema::Image[NRows]);
+		// We require that all items initialized by the Schema processor are PODs, default initialization
+		// by zeroizing should not be a problem. We need to default-init the returned items so that
+		// we can release a partially processed item.
+		std::memset(items.get(), 0, sizeof(typename Schema::Image) * NRows);
 
 		size_t row = 0;
 		try {
@@ -262,7 +268,9 @@ public:
 			return std::make_tuple(std::move(items), NRows);
 		} catch (const CifSchemaError &ex) {
 			// Unwind
-			for (size_t uwdx = 0; uwdx < row; uwdx++)
+			//
+			// the <= is correct because we also need to free a partially-processed item
+			for (size_t uwdx = 0; uwdx <= row; uwdx++)
 				releaseItem(items[uwdx]);
 
 			throw ex;

--- a/src/minicif/schema.hpp
+++ b/src/minicif/schema.hpp
@@ -222,11 +222,22 @@ private:
 
 public:
 	template <typename FixerUpper, typename Releaser>
-	static auto apply(const Block &block, FixerUpper fixerUpper = NoopFixup<typename Schema::Image>, Releaser releaseItem = NoopRelease<typename Schema::Image>)
+	static auto apply(
+		const Block &block,
+		FixerUpper fixerUpper = NoopFixup<typename Schema::Image>,
+		Releaser releaseItem = NoopRelease<typename Schema::Image>,
+		bool allowNoCategory = false
+	)
 	{
 		auto catIt = std::find_if(block.categories.cbegin(), block.categories.cend(), [](const Category &c) { return c.lowecaseName == Schema::name; });
-		if (catIt == block.categories.cend())
+		if (catIt == block.categories.cend()) {
+			if (allowNoCategory) {
+				auto items = std::unique_ptr<typename Schema::Image[]>(nullptr);
+				return std::make_tuple(std::move(items), size_t{0});
+			}
+
 			throw CifSchemaError{"Category " + std::string{Schema::name} + " is not present in block " + block.name};
+		}
 
 		const auto &cat = *catIt;
 

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -172,7 +172,7 @@ void LLKA_CC LLKA_destroyAtom(const LLKA_Atom *atom)
     LLKAInternal::destroyString(atom->label_atom_id);
     LLKAInternal::destroyString(atom->label_entity_id);
     LLKAInternal::destroyString(atom->label_comp_id);
-    LLKAInternal::destroyString(atom->label_asym_id),
+    LLKAInternal::destroyString(atom->label_asym_id);
     LLKAInternal::destroyString(atom->auth_atom_id);
     LLKAInternal::destroyString(atom->auth_comp_id);
     LLKAInternal::destroyString(atom->auth_asym_id);

--- a/tests/test_minicif.cpp
+++ b/tests/test_minicif.cpp
@@ -295,7 +295,7 @@ auto test_no_entry_category()
         "_atom_site.auth_asym_id\n"
         "_atom_site.auth_atom_id\n"
         "_atom_site.pdbx_PDB_model_num\n"
-        "ATOM 1  P P     . DA . 1 99 . . 8.258  14.006  12.104 1 30 ? ? ? ? ? ? 1 DT A P     1\n"
+        "ATOM 1  P P     . DA A 1 99 . . 8.258  14.006  12.104 1 30 ? ? ? ? ? ? 1 DT A P     1\n"
         "#\n"
         "";
 
@@ -346,8 +346,7 @@ auto test_no_entry_category_not_allowed()
         "_atom_site.auth_asym_id\n"
         "_atom_site.auth_atom_id\n"
         "_atom_site.pdbx_PDB_model_num\n"
-        "ATOM 1  P P     . DA . 1 99 . . 8.258  14.006  12.104 1 30 ? ? ? ? ? ? 1 DT A P     1\n"
-        "#\n"
+        "ATOM 1  P P     . DA A 1 99 . . 8.258  14.006  12.104 1 30 ? ? ? ? ? ? 1 DT A P     1\n"
         "";
 
     LLKA_ImportedStructure importedStru{};
@@ -356,6 +355,103 @@ auto test_no_entry_category_not_allowed()
     auto tRet = LLKA_cifTextToStructure(cifText, &importedStru, &error, 0);
     EFF_expect(tRet, LLKA_E_BAD_DATA, "unexpected return value");
     EFF_expect(error, "Category entry is not present in block ", "unexpected error message");
+
+    LLKA_destroyString(error);
+}
+
+static
+auto test_allow_broken_atomsite()
+{
+    static const char *cifText =
+        "data_\n"
+        "loop_\n"
+        "_atom_site.group_PDB\n"
+        "_atom_site.id\n"
+        "_atom_site.type_symbol\n"
+        "_atom_site.label_atom_id\n"
+        "_atom_site.label_alt_id\n"
+        "_atom_site.label_comp_id\n"
+        "_atom_site.label_asym_id\n"
+        "_atom_site.label_entity_id\n"
+        "_atom_site.label_seq_id\n"
+        "_atom_site.pdbx_PDB_ins_code\n"
+        "_atom_site.segment_id\n"
+        "_atom_site.cartn_x\n"
+        "_atom_site.cartn_y\n"
+        "_atom_site.cartn_z\n"
+        "_atom_site.occupancy\n"
+        "_atom_site.B_iso_or_equiv\n"
+        "_atom_site.cartn_x_esd\n"
+        "_atom_site.cartn_y_esd\n"
+        "_atom_site.cartn_z_esd\n"
+        "_atom_site.occupancy_esd\n"
+        "_atom_site.B_iso_or_equiv_esd\n"
+        "_atom_site.pdbx_formal_charge\n"
+        "_atom_site.auth_seq_id\n"
+        "_atom_site.auth_comp_id\n"
+        "_atom_site.auth_asym_id\n"
+        "_atom_site.auth_atom_id\n"
+        "_atom_site.pdbx_PDB_model_num\n"
+        " ATOM 8  N .     . DA . 1 20 . . -2.3707326 -4.507768  -0.94517957  1 20 ? ? ? ? ? ?  1 DA A N9    1\n"
+        "";
+
+    LLKA_ImportedStructure importedStru{};
+    char *error;
+
+    auto tRet = LLKA_cifTextToStructure(cifText, &importedStru, &error, LLKA_MINICIF_ALLOW_NO_ENTRY_CATEGORY | LLKA_MINICIF_ALLOW_BROKEN_ATOMSITE);
+    EFF_expect(tRet, LLKA_OK, "unexpected return value");
+    EFF_expect(error, nullptr, "error should have been set to nullptr");
+
+    EFF_expect(importedStru.structure.nAtoms, 1ULL, "wrong number of atoms in structure");
+    EFF_expect(importedStru.entry.id, "", "unexpected entry id");
+    EFF_expect(importedStru.structure.atoms[0].label_seq_id, 20, "unexpected label_seq_id");
+    EFF_expect(importedStru.structure.atoms[0].label_atom_id, "N9", "unexpected label_atom_id");
+    EFF_expect(importedStru.structure.atoms[0].label_asym_id, "A", "unexpected label_asym_id");
+
+    LLKA_destroyImportedStructure(&importedStru);
+}
+
+static
+auto test_allow_broken_atomsite_not_allowed()
+{
+    static const char *cifText =
+        "data_\n"
+        "loop_\n"
+        "_atom_site.group_PDB\n"
+        "_atom_site.id\n"
+        "_atom_site.type_symbol\n"
+        "_atom_site.label_atom_id\n"
+        "_atom_site.label_alt_id\n"
+        "_atom_site.label_comp_id\n"
+        "_atom_site.label_asym_id\n"
+        "_atom_site.label_entity_id\n"
+        "_atom_site.label_seq_id\n"
+        "_atom_site.pdbx_PDB_ins_code\n"
+        "_atom_site.segment_id\n"
+        "_atom_site.cartn_x\n"
+        "_atom_site.cartn_y\n"
+        "_atom_site.cartn_z\n"
+        "_atom_site.occupancy\n"
+        "_atom_site.B_iso_or_equiv\n"
+        "_atom_site.cartn_x_esd\n"
+        "_atom_site.cartn_y_esd\n"
+        "_atom_site.cartn_z_esd\n"
+        "_atom_site.occupancy_esd\n"
+        "_atom_site.B_iso_or_equiv_esd\n"
+        "_atom_site.pdbx_formal_charge\n"
+        "_atom_site.auth_seq_id\n"
+        "_atom_site.auth_comp_id\n"
+        "_atom_site.auth_asym_id\n"
+        "_atom_site.auth_atom_id\n"
+        "_atom_site.pdbx_PDB_model_num\n"
+        " ATOM 8  N .     . DA . 1 20 . . -2.3707326 -4.507768  -0.94517957  1 20 ? ? ? ? ? ?  1 DA A N9    1\n"
+        "";
+
+    LLKA_ImportedStructure importedStru{};
+    char *error;
+
+    auto tRet = LLKA_cifTextToStructure(cifText, &importedStru, &error, LLKA_MINICIF_ALLOW_NO_ENTRY_CATEGORY);
+    EFF_expect(tRet, LLKA_E_BAD_DATA, "unexpected return value");
 
     LLKA_destroyString(error);
 }
@@ -374,4 +470,7 @@ auto main(int, char **) -> int
 
     test_no_entry_category();
     test_no_entry_category_not_allowed();
+
+    test_allow_broken_atomsite();
+    test_allow_broken_atomsite_not_allowed();
 }

--- a/tests/test_minicif.cpp
+++ b/tests/test_minicif.cpp
@@ -262,6 +262,104 @@ auto test_unterminated_quote()
     LLKA_destroyString(error);
 }
 
+static
+auto test_no_entry_category()
+{
+    static const char *cifText =
+        "data_\n"
+        "loop_\n"
+        "_atom_site.group_PDB\n"
+        "_atom_site.id\n"
+        "_atom_site.type_symbol\n"
+        "_atom_site.label_atom_id\n"
+        "_atom_site.label_alt_id\n"
+        "_atom_site.label_comp_id\n"
+        "_atom_site.label_asym_id\n"
+        "_atom_site.label_entity_id\n"
+        "_atom_site.label_seq_id\n"
+        "_atom_site.pdbx_PDB_ins_code\n"
+        "_atom_site.segment_id\n"
+        "_atom_site.cartn_x\n"
+        "_atom_site.cartn_y\n"
+        "_atom_site.cartn_z\n"
+        "_atom_site.occupancy\n"
+        "_atom_site.B_iso_or_equiv\n"
+        "_atom_site.cartn_x_esd\n"
+        "_atom_site.cartn_y_esd\n"
+        "_atom_site.cartn_z_esd\n"
+        "_atom_site.occupancy_esd\n"
+        "_atom_site.B_iso_or_equiv_esd\n"
+        "_atom_site.pdbx_formal_charge\n"
+        "_atom_site.auth_seq_id\n"
+        "_atom_site.auth_comp_id\n"
+        "_atom_site.auth_asym_id\n"
+        "_atom_site.auth_atom_id\n"
+        "_atom_site.pdbx_PDB_model_num\n"
+        "ATOM 1  P P     . DA . 1 99 . . 8.258  14.006  12.104 1 30 ? ? ? ? ? ? 1 DT A P     1\n"
+        "#\n"
+        "";
+
+    LLKA_ImportedStructure importedStru{};
+    char *error;
+
+    auto tRet = LLKA_cifTextToStructure(cifText, &importedStru, &error, LLKA_MINICIF_ALLOW_NO_ENTRY_CATEGORY);
+    EFF_expect(tRet, LLKA_OK, "unexpected return value");
+    EFF_expect(error, nullptr, "error should have been set to nullptr");
+
+    EFF_expect(importedStru.structure.nAtoms, 1ULL, "wrong number of atoms in structure");
+    EFF_expect(importedStru.structure.atoms[0].label_seq_id, 99, "unexpected label_seq_id");
+    EFF_expect(importedStru.entry.id, "", "unexpected entry id");
+
+    LLKA_destroyImportedStructure(&importedStru);
+}
+
+static
+auto test_no_entry_category_not_allowed()
+{
+    static const char *cifText =
+        "data_\n"
+        "loop_\n"
+        "_atom_site.group_PDB\n"
+        "_atom_site.id\n"
+        "_atom_site.type_symbol\n"
+        "_atom_site.label_atom_id\n"
+        "_atom_site.label_alt_id\n"
+        "_atom_site.label_comp_id\n"
+        "_atom_site.label_asym_id\n"
+        "_atom_site.label_entity_id\n"
+        "_atom_site.label_seq_id\n"
+        "_atom_site.pdbx_PDB_ins_code\n"
+        "_atom_site.segment_id\n"
+        "_atom_site.cartn_x\n"
+        "_atom_site.cartn_y\n"
+        "_atom_site.cartn_z\n"
+        "_atom_site.occupancy\n"
+        "_atom_site.B_iso_or_equiv\n"
+        "_atom_site.cartn_x_esd\n"
+        "_atom_site.cartn_y_esd\n"
+        "_atom_site.cartn_z_esd\n"
+        "_atom_site.occupancy_esd\n"
+        "_atom_site.B_iso_or_equiv_esd\n"
+        "_atom_site.pdbx_formal_charge\n"
+        "_atom_site.auth_seq_id\n"
+        "_atom_site.auth_comp_id\n"
+        "_atom_site.auth_asym_id\n"
+        "_atom_site.auth_atom_id\n"
+        "_atom_site.pdbx_PDB_model_num\n"
+        "ATOM 1  P P     . DA . 1 99 . . 8.258  14.006  12.104 1 30 ? ? ? ? ? ? 1 DT A P     1\n"
+        "#\n"
+        "";
+
+    LLKA_ImportedStructure importedStru{};
+    char *error;
+
+    auto tRet = LLKA_cifTextToStructure(cifText, &importedStru, &error, 0);
+    EFF_expect(tRet, LLKA_E_BAD_DATA, "unexpected return value");
+    EFF_expect(error, "Category entry is not present in block ", "unexpected error message");
+
+    LLKA_destroyString(error);
+}
+
 auto main(int, char **) -> int
 {
     test_ok();
@@ -273,4 +371,7 @@ auto main(int, char **) -> int
 
     test_quote_in_quotes();
     test_unterminated_quote();
+
+    test_no_entry_category();
+    test_no_entry_category_not_allowed();
 }


### PR DESCRIPTION
The reality is that we need to be able to ingest incomplete or partially invalid Cif inputs. More tolerant behavior when processing such Cif inputs is guarded by option flags passed to the Cif parser.